### PR TITLE
8322163: runtime/Unsafe/InternalErrorTest.java fails on Alpine after JDK-8320886

### DIFF
--- a/src/hotspot/share/utilities/copy.cpp
+++ b/src/hotspot/share/utilities/copy.cpp
@@ -243,6 +243,16 @@ void Copy::fill_to_memory_atomic(void* to, size_t size, jubyte value) {
     }
   } else {
     // Not aligned, so no need to be atomic.
+#ifdef MUSL_LIBC
+    // This code is used by Unsafe and may hit the next page after truncation of mapped memory.
+    // Therefore, we use volatile to prevent compilers from replacing the loop by memset which
+    // may not trigger SIGBUS as needed (observed on Alpine Linux x86_64)
+    jbyte fill = value;
+    for (uintptr_t off = 0; off < size; off += sizeof(jbyte)) {
+      *(volatile jbyte*)(dst + off) = fill;
+    }
+#else
     Copy::fill_to_bytes(dst, size, value);
+#endif
   }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322163](https://bugs.openjdk.org/browse/JDK-8322163) needs maintainer approval

### Issue
 * [JDK-8322163](https://bugs.openjdk.org/browse/JDK-8322163): runtime/Unsafe/InternalErrorTest.java fails on Alpine after JDK-8320886 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/8.diff">https://git.openjdk.org/jdk22u/pull/8.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/8#issuecomment-1878371414)