### PR TITLE
8323065: Unneccesary CodeBlob lookup in CompiledIC::internal_set_ic_destination

### DIFF
--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -128,11 +128,13 @@ void CompiledIC::internal_set_ic_destination(address entry_point, bool is_icstub
     tty->cr();
   }
 
+#ifdef ASSERT
   {
     CodeBlob* cb = CodeCache::find_blob(_call->instruction_address());
     assert(cb != nullptr && cb->is_compiled(), "must be compiled");
-    _call->set_destination_mt_safe(entry_point);
   }
+#endif
+  _call->set_destination_mt_safe(entry_point);
 
   if (is_optimized() || is_icstub) {
     // Optimized call sites don't have a cache value and ICStub call


### PR DESCRIPTION
Clean backport for trivial little inefficiency.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8323065](https://bugs.openjdk.org/browse/JDK-8323065) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323065](https://bugs.openjdk.org/browse/JDK-8323065): Unneccesary CodeBlob lookup in CompiledIC::internal_set_ic_destination (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/14.diff">https://git.openjdk.org/jdk22u/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/14#issuecomment-1882950642)