### PR TITLE
8321972: test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2940,6 +2940,17 @@ public:
     return uabs(target - branch) < branch_range;
   }
 
+  // Decode the given instruction, checking if it's a 16-bit compressed
+  // instruction and return the address of the next instruction.
+  static address locate_next_instruction(address inst) {
+    // Instruction wider than 16 bits has the two least-significant bits set.
+    if ((0x3 & *inst) == 0x3) {
+      return inst + instruction_size;
+    } else {
+      return inst + compressed_instruction_size;
+    }
+  }
+
   Assembler(CodeBuffer* code) : AbstractAssembler(code), _in_compressible_region(true) {}
 };
 

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -232,7 +232,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         CompiledMethod* nm = (cb != nullptr) ? cb->as_compiled_method_or_null() : nullptr;
         bool is_unsafe_arraycopy = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
         if ((nm != nullptr && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
-          address next_pc = pc + NativeCall::instruction_size;
+          address next_pc = Assembler::locate_next_instruction(pc);
           if (is_unsafe_arraycopy) {
             next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
           }
@@ -271,7 +271,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                 thread->thread_state() == _thread_in_native) &&
                 sig == SIGBUS && /* info->si_code == BUS_OBJERR && */
                 thread->doing_unsafe_access()) {
-      address next_pc = pc + NativeCall::instruction_size;
+      address next_pc = Assembler::locate_next_instruction(pc);
       if (UnsafeCopyMemory::contains_pc(pc)) {
         next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
       }


### PR DESCRIPTION
Hi! I would like to backport [JDK-8321972](https://bugs.openjdk.org/browse/JDK-8321972) to jdk22u. 
This patch fixes failure of runtime/Unsafe/InternalErrorTest.java after [JDK-8320886](https://bugs.openjdk.org/browse/JDK-8320886) for RISC-V platform, that was backported to jdk22 by [JDK-8321919](https://bugs.openjdk.org/browse/JDK-8321919). 
The original patch applies cleanly. It's related only to RISC-V. No risks for other platforms.
I reproduced this issue on StarFive VisionFive2 board. After appling this patch runtime/Unsafe/InternalErrorTest.java passes.
tier1 tests passed for RISC-V platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321972](https://bugs.openjdk.org/browse/JDK-8321972) needs maintainer approval

### Issue
 * [JDK-8321972](https://bugs.openjdk.org/browse/JDK-8321972): test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/24.diff">https://git.openjdk.org/jdk22u/pull/24.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/24#issuecomment-1895519989)