### PR TITLE
8323657: Compilation of snippet results in VerifyError at runtime with --release 9 (and above)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
@@ -37,6 +37,7 @@ import com.sun.tools.javac.util.*;
 import static com.sun.tools.javac.code.Kinds.Kind.MTH;
 import static com.sun.tools.javac.code.TypeTag.*;
 import static com.sun.tools.javac.jvm.ByteCodes.*;
+import static com.sun.tools.javac.tree.JCTree.Tag.LITERAL;
 import static com.sun.tools.javac.tree.JCTree.Tag.PLUS;
 import com.sun.tools.javac.jvm.Items.*;
 
@@ -416,7 +417,7 @@ public abstract class StringConcat {
                 for (JCTree arg : t) {
                     Object constVal = arg.type.constValue();
                     if ("".equals(constVal)) continue;
-                    if (arg.type == syms.botType) {
+                    if (arg.type == syms.botType && arg.hasTag(LITERAL)) {
                         // Concat the null into the recipe right away
                         recipe.append((String) null);
                     } else if (constVal != null) {

--- a/test/langtools/tools/javac/StringConcat/StringConcatWithAssignments.java
+++ b/test/langtools/tools/javac/StringConcat/StringConcatWithAssignments.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @compile StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ * @compile -XDstringConcat=inline StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ * @compile -XDstringConcat=indy StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ * @compile -XDstringConcat=indyWithConstants StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ */
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class StringConcatWithAssignments {
+    public static void main(String[] args) {
+        StringConcatWithAssignments instance = new StringConcatWithAssignments();
+        assertEquals("nulltrue", instance.assignment());
+        assertEquals("nulltrue", instance.invocation());
+    }
+    private String assignment() {
+        boolean b;
+        return ((((b = true) ? null : null) + "") + b);
+    }
+    private String invocation() {
+        StringBuilder sideEffect = new StringBuilder();
+        Supplier<Boolean> provider = () -> {
+            sideEffect.append(true);
+            return true;
+        };
+        return (((provider.get() ? null : null) + "") + sideEffect.toString());
+    }
+    private static void assertEquals(Object o1, Object o2) {
+        if (!Objects.equals(o1, o2)) {
+            throw new AssertionError("Expected that '" + o1 + "' and " +
+                                     "'" + o2 + "' are equal.");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c9cacfb2](https://github.com/openjdk/jdk/commit/c9cacfb25d1f15c879c961d2965a63c9fe4d9fa7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 22 Jan 2024 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323657](https://bugs.openjdk.org/browse/JDK-8323657) needs maintainer approval

### Issue
 * [JDK-8323657](https://bugs.openjdk.org/browse/JDK-8323657): Compilation of snippet results in VerifyError at runtime with --release 9 (and above) (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/30.diff">https://git.openjdk.org/jdk22u/pull/30.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/30#issuecomment-1910396227)