### PR TITLE
8324041: ModuleOption.java failed with update release versioning scheme

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/ModuleOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/ModuleOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,10 @@ public class ModuleOption {
         final String moduleOption = "jdk.httpserver/sun.net.httpserver.simpleserver.Main";
         final String incubatorModule = "jdk.incubator.vector";
         final String loggingOption = "-Xlog:cds=debug,cds+module=debug,cds+heap=info,module=trace";
-        final String versionPattern = "java.[0-9][0-9][-].*";
+        // Pattern of a module version string.
+        // e.g. JDK 22:     "java 22"
+        //      JDK 22.0.1: "java 22.0.1"
+        final String versionPattern = "java.[0-9][0-9].*";
         final String subgraphCannotBeUsed = "subgraph jdk.internal.module.ArchivedBootLayer cannot be used because full module graph is disabled";
         String archiveName = TestCommon.getNewArchiveName("module-option");
         TestCommon.setCurrentArchiveName(archiveName);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [39005e27](https://github.com/openjdk/jdk/commit/39005e27d6e543def13992740f663b78a8b07671) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Calvin Cheung on 19 Jan 2024 and was reviewed by David Holmes and Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324041](https://bugs.openjdk.org/browse/JDK-8324041) needs maintainer approval

### Issue
 * [JDK-8324041](https://bugs.openjdk.org/browse/JDK-8324041): ModuleOption.java failed with update release versioning scheme (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/35.diff">https://git.openjdk.org/jdk22u/pull/35.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/35#issuecomment-1915191127)