### PR TITLE
8319382: com/sun/jdi/JdwpAllowTest.java shows failures on AIX if prefixLen of mask is larger than 32 in IPv6 case

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -395,18 +395,14 @@ parseAddress(const char *address, struct addrinfo **result) {
     return getAddrInfo(address, hostnameLen, port, &hints, result);
 }
 
-/*
- * Input is sockaddr just because all clients have it.
- */
-static void convertIPv4ToIPv6(const struct sockaddr *addr4, struct in6_addr *addr6) {
+static void convertIPv4ToIPv6(const struct in_addr *addr4, struct in6_addr *addr6) {
     // Implement in a platform-independent way.
     // Spec requires in_addr has s_addr member, in6_addr has s6_addr[16] member.
-    struct in_addr *a4 = &(((struct sockaddr_in*)addr4)->sin_addr);
     memset(addr6, 0, sizeof(*addr6));   // for safety
 
     // Mapped address contains 80 zero bits, then 16 "1" bits, then IPv4 address (4 bytes).
     addr6->s6_addr[10] = addr6->s6_addr[11] = 0xFF;
-    memcpy(&(addr6->s6_addr[12]), &(a4->s_addr), 4);
+    memcpy(&(addr6->s6_addr[12]), &(addr4->s_addr), 4);
 }
 
 /*
@@ -415,37 +411,19 @@ static void convertIPv4ToIPv6(const struct sockaddr *addr4, struct in6_addr *add
  */
 static jdwpTransportError
 parseAllowedAddr(const char *buffer, struct in6_addr *result, int *isIPv4) {
-    struct addrinfo hints;
-    struct addrinfo *addrInfo = NULL;
-    jdwpTransportError err;
-
-    /*
-     * To parse both IPv4 and IPv6 need to specify AF_UNSPEC family
-     * (with AF_INET6 IPv4 addresses are not parsed even with AI_V4MAPPED and AI_ALL flags).
-     */
-    memset (&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;            // IPv6 or mapped IPv4
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_protocol = IPPROTO_TCP;
-    hints.ai_flags = AI_NUMERICHOST;        // only numeric addresses, no resolution
-
-    err = getAddrInfo(buffer, strlen(buffer), NULL, &hints, &addrInfo);
-
-    if (err != JDWPTRANSPORT_ERROR_NONE) {
-        return err;
-    }
-
-    if (addrInfo->ai_family == AF_INET6) {
-        memcpy(result, &(((struct sockaddr_in6 *)(addrInfo->ai_addr))->sin6_addr), sizeof(*result));
+    struct in_addr addr;
+    struct in6_addr addr6;
+    if (inet_pton(AF_INET6, buffer, &addr6) == 1) {
         *isIPv4 = 0;
-    } else {    // IPv4 address - convert to mapped IPv6
-        struct in6_addr addr6;
-        convertIPv4ToIPv6(addrInfo->ai_addr, &addr6);
-        memcpy(result, &addr6, sizeof(*result));
+    } else if (inet_pton(AF_INET, buffer, &addr) == 1) {
+        // IPv4 address - convert to mapped IPv6
+        convertIPv4ToIPv6(&addr, &addr6);
         *isIPv4 = 1;
+    } else {
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
     }
 
-    dbgsysFreeAddrInfo(addrInfo);
+    memcpy(result, &addr6, sizeof(*result));
 
     return JDWPTRANSPORT_ERROR_NONE;
 }
@@ -603,7 +581,8 @@ isPeerAllowed(struct sockaddr_storage *peer) {
     int i;
     // _peers contains IPv6 subnet and mask (IPv4 is converted to mapped IPv6)
     if (peer->ss_family == AF_INET) {
-        convertIPv4ToIPv6((struct sockaddr *)peer, &tmp);
+        struct in_addr *addr4 = &(((struct sockaddr_in*)peer)->sin_addr);
+        convertIPv4ToIPv6(addr4, &tmp);
         addr6 = &tmp;
     } else {
         addr6 = &(((struct sockaddr_in6 *)peer)->sin6_addr);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [22642ff0](https://github.com/openjdk/jdk/commit/22642ff0aac71eceb71f6a9eebb2988a9bd5f091) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Joachim Kern on 17 Jan 2024 and was reviewed by Matthias Baesken and Alex Menkov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8319382](https://bugs.openjdk.org/browse/JDK-8319382): com/sun/jdi/JdwpAllowTest.java shows failures on AIX if prefixLen of mask is larger than 32 in IPv6 case (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/37.diff">https://git.openjdk.org/jdk22u/pull/37.diff</a>

</details>
