### PR TITLE
8323675: Race in jdk.javadoc-gendata

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -962,20 +962,28 @@ else
 
   jdk.jdeps-gendata: java
 
-  # The ct.sym generation uses all the moduleinfos as input
-  jdk.compiler-gendata: $(GENSRC_MODULEINFO_TARGETS) $(JAVA_TARGETS)
-  # jdk.compiler-gendata needs the BUILD_JDK. If the BUILD_JDK was supplied
-  # externally, no extra prerequisites are needed.
+  # jdk.compiler gendata generates ct.sym, which requires all generated
+  # java source and compiled classes present.
+  jdk.compiler-gendata: $(JAVA_TARGETS)
+
+  # jdk.javadoc gendata generates element-list, which requires all java sources
+  # but not compiled classes.
+  jdk.javadoc-gendata: $(GENSRC_TARGETS)
+
+  # ct.sym and element-list generation also needs the BUILD_JDK. If the
+  # BUILD_JDK was supplied externally, no extra prerequisites are needed.
   ifeq ($(CREATE_BUILDJDK), true)
     ifneq ($(CREATING_BUILDJDK), true)
       # When cross compiling and an external BUILD_JDK wasn't supplied, it's
       # produced by the create-buildjdk target.
       jdk.compiler-gendata: create-buildjdk
+      jdk.javadoc-gendata: create-buildjdk
     endif
   else ifeq ($(EXTERNAL_BUILDJDK), false)
     # When not cross compiling, the BUILD_JDK is the interim jdk image, and
     # the javac launcher is needed.
     jdk.compiler-gendata: jdk.compiler-launchers
+    jdk.javadoc-gendata: jdk.compiler-launchers
   endif
 
   # Declare dependencies between jmod targets.


### PR DESCRIPTION
This backports a fix for an intermittent build issue. We just had this break the build for jdk22 RC. The backport attempt to jdk22 missed the RDP2 deadline, but I think it would be nice to get this into 22u to avoid more random build failures there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323675](https://bugs.openjdk.org/browse/JDK-8323675) needs maintainer approval

### Issue
 * [JDK-8323675](https://bugs.openjdk.org/browse/JDK-8323675): Race in jdk.javadoc-gendata (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/53.diff">https://git.openjdk.org/jdk22u/pull/53.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/53#issuecomment-1948395310)