### PR TITLE
Backport fbaaac63d4ae8d7cc0ec02ab4b5a934824d1fec1

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -431,7 +431,6 @@ public class HttpURLConnectionExpectContinueTest {
 
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoOutput(true);
-        connection.setConnectTimeout(1000);
         connection.setReadTimeout(5000);
         connection.setUseCaches(false);
         connection.setInstanceFollowRedirects(false);


### PR DESCRIPTION
This is a backport of JDK-8314164: java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails intermittently in timeout

It is required for backport of JDK-8054022 / https://github.com/openjdk/jdk11u-dev/pull/2523 so i'm trying to bring it back all the way to 11u-dev.

The patch applies clean.

Testing: x86_64 build, affected test