### PR TITLE
8325590: Regression in round-tripping UTF-16 strings after JDK-8311906

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -841,7 +841,7 @@ public final class String
         }
         if (COMPACT_STRINGS) {
             byte[] val = StringUTF16.compress(ca, 0, caLen);
-            int coder = StringUTF16.coderFromArrayLen(val, len);
+            byte coder = StringUTF16.coderFromArrayLen(val, caLen);
             return new String(val, coder);
         }
         return new String(StringUTF16.toBytes(ca, 0, caLen), UTF16);


### PR DESCRIPTION
Can I get a review of this PR which proposes to backport https://bugs.openjdk.org/browse/JDK-8325590 to JDK 22u. This is a clean backport and supersedes the one that Roger opened a few days back https://github.com/openjdk/jdk22u/pull/52. Roger is away so the other PR hasn't yet been integrated. JDK-8325590, as noted in the JBS issue, has been approved for a 22u backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325590](https://bugs.openjdk.org/browse/JDK-8325590) needs maintainer approval

### Issue
 * [JDK-8325590](https://bugs.openjdk.org/browse/JDK-8325590): Regression in round-tripping UTF-16 strings after JDK-8311906 (**Bug** - P1 - Approved)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/55.diff">https://git.openjdk.org/jdk22u/pull/55.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/55#issuecomment-1948736143)