### PR TITLE
8325876: crashes in docker container tests on Linuxppc64le Power8 machines

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,11 @@ public class DockerfileConfig {
             return version;
         }
 
+        // Ubuntu 22.04 ppc started to crash in libz inflateReset on Power8 based host
+        // those recent Ubuntu versions only work on Power9+
+        if (Platform.isPPC()) {
+            return "20.04";
+        }
         return "latest";
     }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325876](https://bugs.openjdk.org/browse/JDK-8325876) needs maintainer approval

### Issue
 * [JDK-8325876](https://bugs.openjdk.org/browse/JDK-8325876): crashes in docker container tests on Linuxppc64le Power8 machines (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/57.diff">https://git.openjdk.org/jdk22u/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/57#issuecomment-1951880007)