### PR TITLE
8326112: Javadoc snippet for Linker.Option.captureCallState is wrong

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -858,7 +858,7 @@ public sealed interface Linker permits AbstractLinker {
          * try (Arena arena = Arena.ofConfined()) {
          *     MemorySegment capturedState = arena.allocate(capturedStateLayout);
          *     handle.invoke(capturedState);
-         *     int errno = (int) errnoHandle.get(capturedState);
+         *     int errno = (int) errnoHandle.get(capturedState, 0L);
          *     // use errno
          * }
          * }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [82609b1e](https://github.com/openjdk/jdk/commit/82609b1ebceb658c612c7ed58959cb159a77d4df) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 19 Feb 2024 and was reviewed by Jorn Vernee.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8326112](https://bugs.openjdk.org/browse/JDK-8326112) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326112](https://bugs.openjdk.org/browse/JDK-8326112): Javadoc snippet for Linker.Option.captureCallState is wrong (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/59.diff">https://git.openjdk.org/jdk22u/pull/59.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/59#issuecomment-1952646845)