### PR TITLE
8325496: Make TrimNativeHeapInterval a product switch

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1992,7 +1992,7 @@ const int ObjectAlignmentInBytes = 8;
           "2: monitors & new lightweight locking (LM_LIGHTWEIGHT)")         \
           range(0, 2)                                                       \
                                                                             \
-  product(uint, TrimNativeHeapInterval, 0, EXPERIMENTAL,                    \
+  product(uint, TrimNativeHeapInterval, 0,                                  \
           "Interval, in ms, at which the JVM will trim the native heap if " \
           "the platform supports that. Lower values will reclaim memory "   \
           "more eagerly at the cost of higher overhead. A value of 0 "      \

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -1480,6 +1480,17 @@ code, and thread.
 In addition to tracking memory usage by JVM subsystems, track memory
 usage by individual \f[V]CallSite\f[R], individual virtual memory region
 and its committed regions.
+.RE
+.TP
+\f[V]-XX:TrimNativeHeapInterval=\f[R]\f[I]millis\f[R]
+Interval, in ms, at which the JVM will trim the native heap.
+Lower values will reclaim memory more eagerly at the cost of higher
+overhead.
+A value of 0 (default) disables native heap trimming.
+Native heap trimming is performed in a dedicated thread.
+.RS
+.PP
+This option is only supported on Linux with GNU C Library (glibc).
 .RE
 .TP
 \f[V]-XX:+NeverActAsServerClassMachine\f[R]

--- a/test/hotspot/jtreg/gtest/NativeHeapTrimmerGtest.java
+++ b/test/hotspot/jtreg/gtest/NativeHeapTrimmerGtest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023 Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,5 +29,5 @@
  * @modules java.base/jdk.internal.misc
  *          java.xml
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=os.trim* -Xlog:trimnative -XX:+UnlockExperimentalVMOptions -XX:TrimNativeHeapInterval=100
+ * @run main/native GTestWrapper --gtest_filter=os.trim* -Xlog:trimnative -XX:TrimNativeHeapInterval=100
  */

--- a/test/hotspot/jtreg/runtime/os/TestTrimNative.java
+++ b/test/hotspot/jtreg/runtime/os/TestTrimNative.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 SAP SE. All rights reserved.
- * Copyright (c) 2023 Red Hat, Inc. All rights reserved.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,7 @@ public class TestTrimNative {
                 long trimInterval = 500; // twice per second
                 long ms1 = System.currentTimeMillis();
                 OutputAnalyzer output = runTestWithOptions(
-                        new String[] { "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=" + trimInterval },
+                        new String[] { "-XX:TrimNativeHeapInterval=" + trimInterval },
                         new String[] { TestTrimNative.Tester.class.getName(), "5000" }
                 );
                 long ms2 = System.currentTimeMillis();
@@ -293,7 +293,7 @@ public class TestTrimNative {
 
             case "trimNativeHighInterval": {
                 OutputAnalyzer output = runTestWithOptions(
-                        new String[] { "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=" + Integer.MAX_VALUE },
+                        new String[] { "-XX:TrimNativeHeapInterval=" + Integer.MAX_VALUE },
                         new String[] { TestTrimNative.Tester.class.getName(), "5000" }
                 );
                 checkExpectedLogMessages(output, true, Integer.MAX_VALUE);
@@ -305,7 +305,7 @@ public class TestTrimNative {
             case "trimNativeLowIntervalStrict": {
                 long ms1 = System.currentTimeMillis();
                 OutputAnalyzer output = runTestWithOptions(
-                        new String[] { "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=1" },
+                        new String[] { "-XX:TrimNativeHeapInterval=1" },
                         new String[] { TestTrimNative.Tester.class.getName(), "0" }
                 );
                 long ms2 = System.currentTimeMillis();
@@ -316,7 +316,7 @@ public class TestTrimNative {
 
             case "testOffOnNonCompliantPlatforms": {
                 OutputAnalyzer output = runTestWithOptions(
-                        new String[] { "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=1" },
+                        new String[] { "-XX:TrimNativeHeapInterval=1" },
                         new String[] { "-version" }
                 );
                 checkExpectedLogMessages(output, false, 0);
@@ -327,7 +327,7 @@ public class TestTrimNative {
 
             case "testOffExplicit": {
                 OutputAnalyzer output = runTestWithOptions(
-                        new String[] { "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=0" },
+                        new String[] { "-XX:TrimNativeHeapInterval=0" },
                         new String[] { "-version" }
                 );
                 checkExpectedLogMessages(output, false, 0);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8325498](https://bugs.openjdk.org/browse/JDK-8325498) to be approved
- [x] Commit message must refer to an issue
- [x] [JDK-8325496](https://bugs.openjdk.org/browse/JDK-8325496) needs maintainer approval

### Issues
 * [JDK-8325496](https://bugs.openjdk.org/browse/JDK-8325496): Make TrimNativeHeapInterval a product switch (**Enhancement** - P4 - Approved)
 * [JDK-8325498](https://bugs.openjdk.org/browse/JDK-8325498): Make TrimNativeHeapInterval a product switch (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/64.diff">https://git.openjdk.org/jdk22u/pull/64.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/64#issuecomment-1959488496)