### PR TITLE
8317299: safepoint scalarization doesn't keep track of the depth of the JVM state

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1463,9 +1463,10 @@ void SafePointNode::disconnect_from_root(PhaseIterGVN *igvn) {
 
 //==============  SafePointScalarObjectNode  ==============
 
-SafePointScalarObjectNode::SafePointScalarObjectNode(const TypeOopPtr* tp, Node* alloc, uint first_index, uint n_fields) :
+SafePointScalarObjectNode::SafePointScalarObjectNode(const TypeOopPtr* tp, Node* alloc, uint first_index, uint depth, uint n_fields) :
   TypeNode(tp, 1), // 1 control input -- seems required.  Get from root.
   _first_index(first_index),
+  _depth(depth),
   _n_fields(n_fields),
   _alloc(alloc)
 {

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -508,7 +508,7 @@ public:
 class SafePointScalarObjectNode: public TypeNode {
   uint _first_index;              // First input edge relative index of a SafePoint node where
                                   // states of the scalarized object fields are collected.
-                                  // It is relative to the last (youngest) jvms->_scloff.
+  uint _depth;                    // Depth of the JVM state the _first_index field refers to
   uint _n_fields;                 // Number of non-static fields of the scalarized object.
 
   Node* _alloc;                   // Just for debugging purposes.
@@ -519,7 +519,7 @@ class SafePointScalarObjectNode: public TypeNode {
   uint first_index() const { return _first_index; }
 
 public:
-  SafePointScalarObjectNode(const TypeOopPtr* tp, Node* alloc, uint first_index, uint n_fields);
+  SafePointScalarObjectNode(const TypeOopPtr* tp, Node* alloc, uint first_index, uint depth, uint n_fields);
 
   virtual int Opcode() const;
   virtual uint           ideal_reg() const;
@@ -529,7 +529,7 @@ public:
 
   uint first_index(JVMState* jvms) const {
     assert(jvms != nullptr, "missed JVMS");
-    return jvms->scloff() + _first_index;
+    return jvms->of_depth(_depth)->scloff() + _first_index;
   }
   uint n_fields()    const { return _n_fields; }
 

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -766,7 +766,7 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
     }
   }
 
-  SafePointScalarObjectNode* sobj = new SafePointScalarObjectNode(res_type, alloc, first_ind, nfields);
+  SafePointScalarObjectNode* sobj = new SafePointScalarObjectNode(res_type, alloc, first_ind, sfpt->jvms()->depth(), nfields);
   sobj->init_req(0, C->root());
   transform_later(sobj);
 

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -276,7 +276,7 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
     SafePointNode* sfpt = safepoints.pop()->as_SafePoint();
 
     uint first_ind = (sfpt->req() - sfpt->jvms()->scloff());
-    Node* sobj = new SafePointScalarObjectNode(vec_box->box_type(), vec_box, first_ind, n_fields);
+    Node* sobj = new SafePointScalarObjectNode(vec_box->box_type(), vec_box, first_ind, sfpt->jvms()->depth(), n_fields);
     sobj->init_req(0, C->root());
     sfpt->add_req(vec_value);
 

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021, 2022, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +34,17 @@ import java.nio.ByteOrder;
  * @summary Vector API intrinsincs should not modify IR when bailing out
  * @modules jdk.incubator.vector
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=1
+ *                   -XX:-TieredCompilation compiler.vectorapi.TestIntrinsicBailOut
+ */
+
+/*
+ * @test
+ * @bug 8317299
+ * @summary Vector API intrinsincs should handle JVM state correctly whith late inlining when compiling with -InlineUnsafeOps
+ * @modules jdk.incubator.vector
+ * @requires vm.cpu.features ~= ".*avx512.*"
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:-InlineUnsafeOps -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3
+ *                   -XX:CompileCommand=compileonly,compiler.vectorapi.TestIntrinsicBailOut::test -XX:CompileCommand=quiet
  *                   -XX:-TieredCompilation compiler.vectorapi.TestIntrinsicBailOut
  */
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6d911f68](https://github.com/openjdk/jdk/commit/6d911f68a3244c40a62ab2570dfec68b8d0ed5d8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Damon Fenacci on 6 Feb 2024 and was reviewed by Tobias Hartmann and Vladimir Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8317299](https://bugs.openjdk.org/browse/JDK-8317299) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317299](https://bugs.openjdk.org/browse/JDK-8317299): safepoint scalarization doesn't keep track of the depth of the JVM state (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/74.diff">https://git.openjdk.org/jdk22u/pull/74.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/74#issuecomment-1968345103)