### PR TITLE
8325028: (ch) Pipe channels should lazily set socket to non-blocking mode on first use by virtual thread

### DIFF
--- a/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,13 @@ class SourceChannelImpl
     // ID of native thread doing read, for signalling
     private long thread;
 
+    // True if the channel's socket has been forced into non-blocking mode
+    // by a virtual thread. It cannot be reset. When the channel is in
+    // blocking mode and the channel's socket is in non-blocking mode then
+    // operations that don't complete immediately will poll the socket and
+    // preserve the semantics of blocking operations.
+    private volatile boolean forcedNonBlocking;
+
     // -- End of fields protected by stateLock
 
 
@@ -79,9 +86,32 @@ class SourceChannelImpl
 
     SourceChannelImpl(SelectorProvider sp, FileDescriptor fd) throws IOException {
         super(sp);
-        IOUtil.configureBlocking(fd, false);
         this.fd = fd;
         this.fdVal = IOUtil.fdVal(fd);
+    }
+
+    /**
+     * Checks that the channel is open.
+     *
+     * @throws ClosedChannelException if channel is closed (or closing)
+     */
+    private void ensureOpen() throws ClosedChannelException {
+        if (!isOpen())
+            throw new ClosedChannelException();
+    }
+
+    /**
+     * Ensures that the socket is configured non-blocking when on a virtual thread.
+     */
+    private void configureSocketNonBlockingIfVirtualThread() throws IOException {
+        assert readLock.isHeldByCurrentThread();
+        if (!forcedNonBlocking && Thread.currentThread().isVirtual()) {
+            synchronized (stateLock) {
+                ensureOpen();
+                IOUtil.configureBlocking(fd, false);
+                forcedNonBlocking = true;
+            }
+        }
     }
 
     /**
@@ -183,9 +213,11 @@ class SourceChannelImpl
         readLock.lock();
         try {
             synchronized (stateLock) {
-                if (!isOpen())
-                    throw new ClosedChannelException();
-                IOUtil.configureBlocking(fd, block);
+                ensureOpen();
+                // do nothing if virtual thread has forced the socket to be non-blocking
+                if (!forcedNonBlocking) {
+                    IOUtil.configureBlocking(fd, block);
+                }
             }
         } finally {
             readLock.unlock();
@@ -241,8 +273,7 @@ class SourceChannelImpl
             begin();
         }
         synchronized (stateLock) {
-            if (!isOpen())
-                throw new ClosedChannelException();
+            ensureOpen();
             if (blocking)
                 thread = NativeThread.current();
         }
@@ -279,6 +310,7 @@ class SourceChannelImpl
             int n = 0;
             try {
                 beginRead(blocking);
+                configureSocketNonBlockingIfVirtualThread();
                 n = IOUtil.read(fd, dst, -1, nd);
                 if (blocking) {
                     while (IOStatus.okayToRetry(n) && isOpen()) {
@@ -306,6 +338,7 @@ class SourceChannelImpl
             long n = 0;
             try {
                 beginRead(blocking);
+                configureSocketNonBlockingIfVirtualThread();
                 n = IOUtil.read(fd, dsts, offset, length, nd);
                 if (blocking) {
                     while (IOStatus.okayToRetry(n) && isOpen()) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d1099033](https://github.com/openjdk/jdk/commit/d1099033ac63b9dd0dd6e3a7341db929e9e0e56e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alan Bateman on 8 Feb 2024 and was reviewed by Brian Burkhalter.

This change fixes a bug in jruby[1] that broken pipeline functions of Open3[1][2].

Thanks!

[1] https://github.com/jruby/jruby/issues/8069
[2] https://bugs.launchpad.net/ubuntu/+source/jruby/+bug/2054943

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325028](https://bugs.openjdk.org/browse/JDK-8325028) needs maintainer approval

### Issue
 * [JDK-8325028](https://bugs.openjdk.org/browse/JDK-8325028): (ch) Pipe channels should lazily set socket to non-blocking mode on first use by virtual thread (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/79.diff">https://git.openjdk.org/jdk22u/pull/79.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/79#issuecomment-1972756575)