### PR TITLE
8326140: src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp ReleaseStringChars might be missing in early returns

### DIFF
--- a/src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp
+++ b/src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,6 +77,22 @@ AccessBridgeJavaEntryPoints::~AccessBridgeJavaEntryPoints() {
 #define EXCEPTION_CHECK(situationDescription, returnVal)                                        \
     if (exception = jniEnv->ExceptionOccurred()) {                                              \
         PrintDebugString("[ERROR]: *** Exception occured while doing: %s; returning %d", situationDescription, returnVal);   \
+        jniEnv->ExceptionDescribe();                                                            \
+        jniEnv->ExceptionClear();                                                               \
+        return (returnVal);                                                                     \
+    }
+
+#define EXCEPTION_CHECK_WITH_RELEASE(situationDescription, returnVal, js, stringBytes)          \
+    if (exception = jniEnv->ExceptionOccurred()) {                                              \
+        PrintDebugString("[ERROR]: *** Exception occured while doing: %s - call to GetStringLength; returning %d", situationDescription, returnVal);   \
+        jniEnv->ExceptionDescribe();                                                            \
+        jniEnv->ExceptionClear();                                                               \
+        jniEnv->ReleaseStringChars(js, stringBytes);                                            \
+        return (returnVal);                                                                     \
+    }                                                                                           \
+    jniEnv->ReleaseStringChars(js, stringBytes);                                                \
+    if (exception = jniEnv->ExceptionOccurred()) {                                              \
+        PrintDebugString("[ERROR]: *** Exception occured while doing: %s - call to ReleaseStringChars; returning %d", situationDescription, returnVal);   \
         jniEnv->ExceptionDescribe();                                                            \
         jniEnv->ExceptionClear();                                                               \
         return (returnVal);                                                                     \
@@ -1215,9 +1231,7 @@ AccessBridgeJavaEntryPoints::getVirtualAccessibleName (
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(name, stringBytes, nameSize - 1);
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK("Getting AccessibleName - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod (
                 accessBridgeObject,
                 decrementReferenceMethod, js);
@@ -1380,9 +1394,7 @@ AccessBridgeJavaEntryPoints::getTextAttributesInRange(const jobject accessibleCo
                 length = jniEnv->GetStringLength(js);
                 test_attributes.fullAttributesString[length < (sizeof(test_attributes.fullAttributesString) / sizeof(wchar_t)) ?
                                                      length : (sizeof(test_attributes.fullAttributesString) / sizeof(wchar_t))-2] = (wchar_t) 0;
-                EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE);
-                jniEnv->ReleaseStringChars(js, stringBytes);
-                EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to ReleaseStringChars()", FALSE);
+                EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex", FALSE, js, stringBytes);
                 jniEnv->CallVoidMethod(accessBridgeObject,
                                        decrementReferenceMethod, js);
                 EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to CallVoidMethod()", FALSE);
@@ -1735,11 +1747,9 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(info->name, stringBytes, (sizeof(info->name) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName", FALSE, js, stringBytes);
             info->name[length < (sizeof(info->name) / sizeof(wchar_t)) ?
                        length : (sizeof(info->name) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleName - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleName - call to CallVoidMethod()", FALSE);
@@ -1767,11 +1777,9 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(info->description, stringBytes, (sizeof(info->description) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName", FALSE, js, stringBytes);
             info->description[length < (sizeof(info->description) / sizeof(wchar_t)) ?
                               length : (sizeof(info->description) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleName - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleName - call to CallVoidMethod()", FALSE);
@@ -1799,11 +1807,9 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRole - call to GetStringChars()", FALSE);
             wcsncpy(info->role, stringBytes, (sizeof(info->role) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole", FALSE, js, stringBytes);
             info->role[length < (sizeof(info->role) / sizeof(wchar_t)) ?
                        length : (sizeof(info->role) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleRole - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRole - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleRole - call to CallVoidMethod()", FALSE);
@@ -1831,11 +1837,9 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to GetStringChars()", FALSE);
             wcsncpy(info->role_en_US, stringBytes, (sizeof(info->role_en_US) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole_en_US", FALSE, js, stringBytes);
             info->role_en_US[length < (sizeof(info->role_en_US) / sizeof(wchar_t)) ?
                              length : (sizeof(info->role_en_US) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to CallVoidMethod()", FALSE);
@@ -1862,11 +1866,9 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleState - call to GetStringChars()", FALSE);
             wcsncpy(info->states, stringBytes, (sizeof(info->states) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState", FALSE, js, stringBytes);
             info->states[length < (sizeof(info->states) / sizeof(wchar_t)) ?
                          length : (sizeof(info->states) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleState - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleState - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleState - call to CallVoidMethod()", FALSE);
@@ -1893,11 +1895,9 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleState_en_US - call to GetStringChars()", FALSE);
             wcsncpy(info->states_en_US, stringBytes, (sizeof(info->states_en_US) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState_en_US", FALSE, js, stringBytes);
             info->states_en_US[length < (sizeof(info->states_en_US) / sizeof(wchar_t)) ?
                                length : (sizeof(info->states_en_US) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleState_en_US - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleState_en_US - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleState_en_US - call to CallVoidMethod()", FALSE);
@@ -2809,11 +2809,9 @@ AccessBridgeJavaEntryPoints::getAccessibleRelationSet(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRelation key - call to GetStringChars()", FALSE);
             wcsncpy(relationSet->relations[i].key, stringBytes, (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRelation key", FALSE, js, stringBytes);
             relationSet->relations[i].key [length < (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t)) ?
                                            length : (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleRelation key - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRelation key - call to ReleaseStringChars()", FALSE);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleRelation key - call to CallVoidMethod()", FALSE);
@@ -2915,9 +2913,7 @@ AccessBridgeJavaEntryPoints::getAccessibleHypertext(jobject accessibleContext,
                 length = (sizeof(hypertext->links[i].text) / sizeof(wchar_t)) - 2;
             }
             hypertext->links[i].text[length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                                     decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to CallVoidMethod()", FALSE);
@@ -3052,9 +3048,7 @@ AccessBridgeJavaEntryPoints::getAccessibleHypertextExt(const jobject accessibleC
                 length = (sizeof(hypertext->links[bufIndex].text) / sizeof(wchar_t)) - 2;
             }
             hypertext->links[bufIndex].text[length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to CallVoidMethod()", FALSE);
@@ -3171,9 +3165,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleHyperlink(jobject hypertext,
             length = (sizeof(info->text) / sizeof(wchar_t)) - 2;
         }
         info->text[length] = (wchar_t) 0;
-        EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE);
-        jniEnv->ReleaseStringChars(js, stringBytes);
-        EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
+        EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text", FALSE, js, stringBytes);
         // jniEnv->CallVoidMethod(accessBridgeObject,
         //                        decrementReferenceMethod, js);
         //EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to CallVoidMethod()", FALSE);
@@ -3300,9 +3292,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleIcons(jobject accessibleContext,
                 length = (sizeof(icons->iconInfo[i].description) / sizeof(wchar_t)) - 2;
             }
             icons->iconInfo[i].description[length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleIcon description - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleIcon description - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleIcon description", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleIcon description - call to CallVoidMethod()", FALSE);
@@ -3379,9 +3369,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleActions(jobject accessibleContext
                 length = (sizeof(actions->actionInfo[i].name ) / sizeof(wchar_t)) - 2;
             }
             actions->actionInfo[i].name [length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleAction name  - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleAction name  - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAction name", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleAction name  - call to CallVoidMethod()", FALSE);
@@ -3561,9 +3549,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextItems(jobject accessibleContext,
             length = jniEnv->GetStringLength(js);
             textItems->word[length < (sizeof(textItems->word) / sizeof(wchar_t)) ?
                             length : (sizeof(textItems->word) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleWordAtIndex - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleWordAtIndex - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleWordAtIndex", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleWordAtIndex - call to CallVoidMethod()", FALSE);
@@ -3597,9 +3583,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextItems(jobject accessibleContext,
             } else {
                 textItems->sentence[(sizeof(textItems->sentence) / sizeof(wchar_t))-2] = (wchar_t) 0;
             }
-            EXCEPTION_CHECK("Getting AccessibleSentenceAtIndex - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleSentenceAtIndex - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleSentenceAtIndex", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleSentenceAtIndex - call to CallVoidMethod()", FALSE);
@@ -3673,9 +3657,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextSelectionInfo(jobject accessibleCo
             length = jniEnv->GetStringLength(js);
             selectionInfo->selectedText[length < (sizeof(selectionInfo->selectedText) / sizeof(wchar_t)) ?
                                         length : (sizeof(selectionInfo->selectedText) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleTextSelectedText - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleTextSelectedText - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextSelectedText", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleTextSelectedText - call to CallVoidMethod()", FALSE);
@@ -3890,9 +3872,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->backgroundColor[length < (sizeof(attributes->backgroundColor) / sizeof(wchar_t)) ?
                                         length : (sizeof(attributes->backgroundColor) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting BackgroundColorFromAttributeSet - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting BackgroundColorFromAttributeSet - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting BackgroundColorFromAttributeSet", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting BackgroundColorFromAttributeSet - call to CallVoidMethod()", FALSE);
@@ -3927,9 +3907,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->foregroundColor[length < (sizeof(attributes->foregroundColor) / sizeof(wchar_t)) ?
                                         length : (sizeof(attributes->foregroundColor) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting ForegroundColorFromAttributeSet - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting ForegroundColorFromAttributeSet - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting ForegroundColorFromAttributeSet", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting ForegroundColorFromAttributeSet - call to CallVoidMethod()", FALSE);
@@ -3964,9 +3942,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->fontFamily[length < (sizeof(attributes->fontFamily) / sizeof(wchar_t)) ?
                                    length : (sizeof(attributes->fontFamily) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting FontFamilyFromAttributeSet - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting FontFamilyFromAttributeSet - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting FontFamilyFromAttributeSet", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting FontFamilyFromAttributeSet - call to CallVoidMethod()", FALSE);
@@ -4170,9 +4146,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->fullAttributesString[length < (sizeof(attributes->fullAttributesString) / sizeof(wchar_t)) ?
                                              length : (sizeof(attributes->fullAttributesString) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to CallVoidMethod()", FALSE);
@@ -4413,9 +4387,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextRange(jobject accessibleContext,
             PrintDebugString("[INFO]:  Accessible Text stringBytes length = %d", length);
             text[length < len ? length : len - 2] = (wchar_t) 0;
             wPrintDebugString(L"[INFO]:   Accessible Text 'text' after null termination = %ls", text);
-            EXCEPTION_CHECK("Getting AccessibleTextRange - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleTextRange - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextRange", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleTextRange - call to CallVoidMethod()", FALSE);
@@ -4458,9 +4430,7 @@ AccessBridgeJavaEntryPoints::getCurrentAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting CurrentAccessibleValue - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting CurrentAccessibleValue - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting CurrentAccessibleValue", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting CurrentAccessibleValue - call to CallVoidMethod()", FALSE);
@@ -4501,9 +4471,7 @@ AccessBridgeJavaEntryPoints::getMaximumAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting MaximumAccessibleValue - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting MaximumAccessibleValue - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting MaximumAccessibleValue", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting MaximumAccessibleValue - call to CallVoidMethod()", FALSE);
@@ -4544,9 +4512,7 @@ AccessBridgeJavaEntryPoints::getMinimumAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting MinimumAccessibleValue - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting MinimumAccessibleValue - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting MinimumAccessibleValue", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting MinimumAccessibleValue - call to CallVoidMethod()", FALSE);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326140](https://bugs.openjdk.org/browse/JDK-8326140) needs maintainer approval

### Issue
 * [JDK-8326140](https://bugs.openjdk.org/browse/JDK-8326140): src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp ReleaseStringChars might be missing in early returns (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/91.diff">https://git.openjdk.org/jdk22u/pull/91.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/91#issuecomment-1983572702)