### PR TITLE
8326529: JFR: Test for CompilerCompile events fails due to time out

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
@@ -47,6 +47,7 @@ import jdk.test.whitebox.WhiteBox;
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:CompileOnly=jdk.jfr.event.compiler.TestCompilerCompile::dummyMethod,jdk.jfr.event.compiler.TestCompilerCompile::doTest
  *     jdk.jfr.event.compiler.TestCompilerCompile
  */
 public class TestCompilerCompile {


### PR DESCRIPTION
This is a backport of https://github.com/openjdk/jdk/commit/4dd6c44cbdb0b5957414fa87b6c559fa4d6f2fa8

This backport limits compilation only to the test methods [TestCompileCompile](https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java) cares about. It should help resolve some test failures for Adoptium (see https://github.com/adoptium/aqa-tests/issues/3046).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326529](https://bugs.openjdk.org/browse/JDK-8326529) needs maintainer approval

### Issue
 * [JDK-8326529](https://bugs.openjdk.org/browse/JDK-8326529): JFR: Test for CompilerCompile events fails due to time out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/93.diff">https://git.openjdk.org/jdk22u/pull/93.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/93#issuecomment-1986487331)