### PR TITLE
8324648: Avoid NoSuchMethodError when instantiating NativePRNG

### DIFF
--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,10 +203,12 @@ public final class NativePRNG extends SecureRandomSpi {
     }
 
     // constructor, called by the JCA framework
-    public NativePRNG() {
-        super();
+    public NativePRNG(SecureRandomParameters params) {
         if (INSTANCE == null) {
             throw new AssertionError("NativePRNG not available");
+        }
+        if (params != null) {
+            throw new IllegalArgumentException("Unsupported params: " + params.getClass());
         }
     }
 
@@ -251,10 +253,12 @@ public final class NativePRNG extends SecureRandomSpi {
         }
 
         // constructor, called by the JCA framework
-        public Blocking() {
-            super();
+        public Blocking(SecureRandomParameters params) {
             if (INSTANCE == null) {
                 throw new AssertionError("NativePRNG$Blocking not available");
+            }
+            if (params != null) {
+                throw new IllegalArgumentException("Unsupported params: " + params.getClass());
             }
         }
 
@@ -300,11 +304,13 @@ public final class NativePRNG extends SecureRandomSpi {
         }
 
         // constructor, called by the JCA framework
-        public NonBlocking() {
-            super();
+        public NonBlocking(SecureRandomParameters params) {
             if (INSTANCE == null) {
                 throw new AssertionError(
                     "NativePRNG$NonBlocking not available");
+            }
+            if (params != null) {
+                throw new IllegalArgumentException("Unsupported params: " + params.getClass());
             }
         }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [69b2674c](https://github.com/openjdk/jdk/commit/69b2674c6861fdb7d9f9cb39e07d50515c73e33a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Oli Gillespie on 9 Feb 2024 and was reviewed by Aleksey Shipilev, Weijun Wang, Chen Liang and Valerie Peng.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324648](https://bugs.openjdk.org/browse/JDK-8324648) needs maintainer approval

### Issue
 * [JDK-8324648](https://bugs.openjdk.org/browse/JDK-8324648): Avoid NoSuchMethodError when instantiating NativePRNG (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/99.diff">https://git.openjdk.org/jdk22u/pull/99.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/99#issuecomment-1991495503)