### PR TITLE
8326521: JFR: CompilerPhase event test fails on windows 32 bit

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java
@@ -42,6 +42,7 @@ import jdk.test.whitebox.WhiteBox;
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:-NeverActAsServerClassMachine
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:CompileOnly=jdk.jfr.event.compiler.TestCompilerPhase::dummyMethod
  *     -XX:+SegmentedCodeCache -Xbootclasspath/a:.


### PR DESCRIPTION
This is a backport of https://github.com/openjdk/jdk/commit/96530bcc07514c3eda40fd6ffa74f197fe541dea

On some systems (such as windows 32 bit) Hotspot only uses the C1 compiler in by design. The CompilerPhase JFR events are only emitted from C2 code. So the test `TestCompilerPhase` fails on some systems because it cannot generate the necessary CompilerPhase JFR events . 

This backport prevents `NeverActAsServerClassMachine` from being set during the test `TestCompilerPhase`, so that it isn't restricted to C1. It should help resolve some test failures for Adoptium (see https://github.com/adoptium/aqa-tests/issues/3045).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8326521](https://bugs.openjdk.org/browse/JDK-8326521) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326521](https://bugs.openjdk.org/browse/JDK-8326521): JFR: CompilerPhase event test fails on windows 32 bit (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/112.diff">https://git.openjdk.org/jdk22u/pull/112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/112#issuecomment-2015841669)