### PR TITLE
8328705: GHA: Cross-compilation jobs do not require build JDK

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -93,13 +93,6 @@ jobs:
         with:
           platform: linux-x64
 
-        # Use linux-x64 JDK bundle as build JDK
-      - name: 'Get build JDK'
-        id: buildjdk
-        uses: ./.github/actions/get-bundles
-        with:
-          platform: linux-x64
-
       - name: 'Get GTest'
         id: gtest
         uses: ./.github/actions/get-gtest
@@ -165,7 +158,6 @@ jobs:
           --disable-precompiled-headers
           --openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}
           --with-sysroot=sysroot
-          --with-build-jdk=${{ steps.buildjdk.outputs.jdk-path }}
           --with-jmod-compress=zip-1
           CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
           CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,8 +133,7 @@ jobs:
       gcc-major-version: '10'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
-    if: needs.select.outputs.linux-x64 == 'true' || needs.select.outputs.linux-cross-compile == 'true'
+    if: needs.select.outputs.linux-x64 == 'true'
 
   build-linux-x86:
     name: linux-x86
@@ -214,7 +213,6 @@ jobs:
     name: linux-cross-compile
     needs:
       - select
-      - build-linux-x64
     uses: ./.github/workflows/build-cross-compile.yml
     with:
       gcc-major-version: '10'


### PR DESCRIPTION
Clean backport to improve GHA parallelism.

Additional testing:
 - [ ] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328705](https://bugs.openjdk.org/browse/JDK-8328705) needs maintainer approval

### Issue
 * [JDK-8328705](https://bugs.openjdk.org/browse/JDK-8328705): GHA: Cross-compilation jobs do not require build JDK (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/113.diff">https://git.openjdk.org/jdk22u/pull/113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/113#issuecomment-2017835299)