### PR TITLE
8328316: Finisher cannot emit if stream is sequential and integrator returned false

### DIFF
--- a/src/java.base/share/classes/java/util/stream/GathererOp.java
+++ b/src/java.base/share/classes/java/util/stream/GathererOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,6 +142,7 @@ final class GathererOp<T, A, R> extends ReferencePipeline<T, R> {
         private final Integrator<A, T, R> integrator; // Optimization: reuse
         private A state;
         private boolean proceed = true;
+        private boolean downstreamProceed = true;
 
         GatherSink(Gatherer<T, A, R> gatherer, Sink<R> sink) {
             this.gatherer = gatherer;
@@ -173,12 +174,12 @@ final class GathererOp<T, A, R> extends ReferencePipeline<T, R> {
 
         @Override
         public boolean cancellationRequested() {
-            return cancellationRequested(proceed);
+            return cancellationRequested(proceed && downstreamProceed);
         }
 
         private boolean cancellationRequested(boolean knownProceed) {
             // Highly performance sensitive
-            return !(knownProceed && (!sink.cancellationRequested() || (proceed = false)));
+            return !(knownProceed && (!sink.cancellationRequested() || (downstreamProceed = false)));
         }
 
         @Override
@@ -194,12 +195,12 @@ final class GathererOp<T, A, R> extends ReferencePipeline<T, R> {
 
         @Override
         public boolean isRejecting() {
-            return !proceed;
+            return !downstreamProceed;
         }
 
         @Override
         public boolean push(R r) {
-            var p = proceed;
+            var p = downstreamProceed;
             if (p)
                 sink.accept(r);
             return !cancellationRequested(p);

--- a/test/jdk/java/util/stream/GathererShortCircuitTest.java
+++ b/test/jdk/java/util/stream/GathererShortCircuitTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Gatherer;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+/**
+ * @test
+ * @bug 8328316
+ * @summary Testing Gatherer behavior under short circuiting
+ * @enablePreview
+ * @run junit GathererShortCircuitTest
+ */
+
+public class GathererShortCircuitTest {
+    @Test
+    public void mustBeAbleToPushFromFinisher() {
+        Integer expected = 8328316;
+        List<Integer> source = List.of(1,2,3,4,5);
+
+        Gatherer<Integer, ?, Integer> pushOneInFinisher =
+                Gatherer.of(
+                    (_, element, downstream) -> false,
+                    (_, downstream) -> downstream.push(expected)
+                );
+
+        var usingCollect =
+            source.stream().gather(pushOneInFinisher).collect(Collectors.toList());
+        var usingBuiltin =
+            source.stream().gather(pushOneInFinisher).toList();
+        var usingCollectPar =
+            source.stream().parallel().gather(pushOneInFinisher).collect(Collectors.toList());
+        var usingBuiltinPar =
+            source.stream().parallel().gather(pushOneInFinisher).toList();
+
+        assertEquals(List.of(expected), usingCollect);
+        assertEquals(List.of(expected), usingBuiltin);
+        assertEquals(List.of(expected), usingCollectPar);
+        assertEquals(List.of(expected), usingBuiltinPar);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ab28045d](https://github.com/openjdk/jdk/commit/ab28045d7785d948b2bce685f06043e8217961f4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository addressing [JDK-8328316](https://bugs.openjdk.org/browse/JDK-8328316).

The commit being backported was authored by Viktor Klang on 21 Mar 2024 and was reviewed by Paul Sandoz.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328316](https://bugs.openjdk.org/browse/JDK-8328316) needs maintainer approval

### Issue
 * [JDK-8328316](https://bugs.openjdk.org/browse/JDK-8328316): Finisher cannot emit if stream is sequential and integrator returned false (**Bug** - P4 - Approved)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/118.diff">https://git.openjdk.org/jdk22u/pull/118.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/118#issuecomment-2031191125)