### PR TITLE
8319548: Unexpected internal name for Filler array klass causes error in VisualVM

### DIFF
--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -338,7 +338,7 @@ void Universe::genesis(TRAPS) {
       // Initialization of the fillerArrayKlass must come before regular
       // int-TypeArrayKlass so that the int-Array mirror points to the
       // int-TypeArrayKlass.
-      _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "Ljdk/internal/vm/FillerArray;", CHECK);
+      _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "[Ljdk/internal/vm/FillerElement;", CHECK);
       for (int i = T_BOOLEAN; i < T_LONG+1; i++) {
         _typeArrayKlassObjs[i] = TypeArrayKlass::create_klass((BasicType)i, CHECK);
       }

--- a/test/hotspot/jtreg/gc/TestFillerObjectInstantiation.java
+++ b/test/hotspot/jtreg/gc/TestFillerObjectInstantiation.java
@@ -45,6 +45,6 @@ public class TestFillerObjectInstantiation {
 
     public static void main(String[] args) throws Exception {
         testInstantiationFails("jdk.internal.vm.FillerObject");
-        testInstantiationFails("jdk.internal.vm.FillerArray");
+        testInstantiationFails("jdk.internal.vm.FillerElement");
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [05745e3f](https://github.com/openjdk/jdk/commit/05745e3f1d56f71d7647e81fa5933c9f4ed18430) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 21 Dec 2023 and was reviewed by Albert Mingkun Yang and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319548](https://bugs.openjdk.org/browse/JDK-8319548) needs maintainer approval

### Issue
 * [JDK-8319548](https://bugs.openjdk.org/browse/JDK-8319548): Unexpected internal name for Filler array klass causes error in VisualVM (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/119.diff">https://git.openjdk.org/jdk22u/pull/119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/119#issuecomment-2031431928)