### PR TITLE
8325567: jspawnhelper without args fails with segfault

### DIFF
--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -63,6 +63,7 @@ void shutItDown() {
     fprintf(stdout, "only be run as the result of a call to\n");
     fprintf(stdout, "ProcessBuilder.start() or Runtime.exec() in a java ");
     fprintf(stdout, "application\n");
+    fflush(stdout);
     _exit(1);
 }
 
@@ -139,6 +140,10 @@ int main(int argc, char *argv[]) {
     /* argv[1] contains the fd number to read all the child info */
     int r, fdinr, fdinw, fdout;
     sigset_t unblock_signals;
+
+    if (argc != 2) {
+        shutItDown();
+    }
 
 #ifdef DEBUG
     jtregSimulateCrash(0, 4);

--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8325567
+ * @requires (os.family == "linux") | (os.family == "aix") | (os.family == "mac")
+ * @library /test/lib
+ * @run driver JspawnhelperWarnings
+ */
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class JspawnhelperWarnings {
+
+    private static void tryWithNArgs(int nArgs) throws Exception {
+        System.out.println("Running jspawnhelper with " + nArgs + " args");
+        String[] args = new String[nArgs + 1];
+        Arrays.fill(args, "1");
+        args[0] = Paths.get(System.getProperty("java.home"), "lib", "jspawnhelper").toString();
+        Process p = ProcessTools.startProcess("jspawnhelper", new ProcessBuilder(args));
+        OutputAnalyzer oa = new OutputAnalyzer(p);
+        oa.shouldHaveExitValue(1);
+        oa.shouldContain("This command is not for general use");
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (int nArgs = 0; nArgs < 10; nArgs++) {
+            tryWithNArgs(nArgs);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to improve jspawnhelper resiliency and provide the grounds for later backports.

Additional testing:
 - [x] jspawnhelper no longer SEGVs when ran manually
 - [x] `java/lang/ProcessBuilder` tests pass, including new test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8325567](https://bugs.openjdk.org/browse/JDK-8325567) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325567](https://bugs.openjdk.org/browse/JDK-8325567): jspawnhelper without args fails with segfault (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/126.diff">https://git.openjdk.org/jdk22u/pull/126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/126#issuecomment-2036610354)