### PR TITLE
8329545: [s390x] Fix garbage value being passed in Argument Register

### DIFF
--- a/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
+++ b/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -166,7 +166,7 @@ static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, 
     case StorageType::INTEGER:
       switch (from_reg.stack_size()) {
         case 8: __ mem2reg_opt(as_Register(to_reg), from_addr, true);break;
-        case 4: __ mem2reg_opt(as_Register(to_reg), from_addr, false);break;
+        case 4: __ mem2reg_signed_opt(as_Register(to_reg), from_addr);break;
         default: ShouldNotReachHere();
       }
       break;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit e0fd6c4c from the openjdk/jdk repository.

The commit being backported was authored by Sidraya Jayagond on 10 Apr 2024 and was reviewed by Amit Kumar and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329545](https://bugs.openjdk.org/browse/JDK-8329545) needs maintainer approval

### Issue
 * [JDK-8329545](https://bugs.openjdk.org/browse/JDK-8329545): [s390x] Fix garbage value being passed in Argument Register (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/137.diff">https://git.openjdk.org/jdk22u/pull/137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/137#issuecomment-2047424151)