### PR TITLE
8329656: assertion failed in MAP_ARCHIVE_MMAP_FAILURE path: Invalid immediate -5 0

### DIFF
--- a/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
@@ -57,15 +57,15 @@ static char* reserve_at_eor_compatible_address(size_t size, bool aslr) {
       0x7800, 0x7c00, 0x7e00, 0x7f00, 0x7f80, 0x7fc0, 0x7fe0, 0x7ff0, 0x7ff8,
       0x7ffc, 0x7ffe, 0x7fff
   };
-  static constexpr int num_immediates = sizeof(immediates) / sizeof(immediates[0]);
-  const int start_index = aslr ? os::next_random((int)os::javaTimeNanos()) : 0;
+  static constexpr unsigned num_immediates = sizeof(immediates) / sizeof(immediates[0]);
+  const unsigned start_index = aslr ? os::next_random((int)os::javaTimeNanos()) : 0;
   constexpr int max_tries = 64;
   for (int ntry = 0; result == nullptr && ntry < max_tries; ntry ++) {
     // As in os::attempt_reserve_memory_between, we alternate between higher and lower
     // addresses; this maximizes the chance of early success if part of the address space
     // is not accessible (e.g. 39-bit address space).
-    const int alt_index = (ntry & 1) ? 0 : num_immediates / 2;
-    const int index = (start_index + ntry + alt_index) % num_immediates;
+    const unsigned alt_index = (ntry & 1) ? 0 : num_immediates / 2;
+    const unsigned index = (start_index + ntry + alt_index) % num_immediates;
     const uint64_t immediate = ((uint64_t)immediates[index]) << 32;
     assert(immediate > 0 && Assembler::operand_valid_for_logical_immediate(/*is32*/false, immediate),
            "Invalid immediate %d " UINT64_FORMAT, index, immediate);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d9c84e76](https://github.com/openjdk/jdk/commit/d9c84e763a0880d33586dbb8dc90b66ede030444) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 11 Apr 2024 and was reviewed by Calvin Cheung and Ioi Lam.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8329656](https://bugs.openjdk.org/browse/JDK-8329656) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329656](https://bugs.openjdk.org/browse/JDK-8329656): assertion failed in MAP_ARCHIVE_MMAP_FAILURE path: Invalid immediate -5 0 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/139.diff">https://git.openjdk.org/jdk22u/pull/139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/139#issuecomment-2048972029)