### PR TITLE
8330176: Typo in Linker javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -598,7 +598,7 @@ public sealed interface Linker permits AbstractLinker {
      * <p>
      * Calling this method is equivalent to the following code:
      * {@snippet lang=java :
-     * linker.downcallHandle(function).bindTo(symbol);
+     * linker.downcallHandle(function, options).bindTo(address);
      * }
      *
      * @param address  the native memory segment whose


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [60d88b7a](https://github.com/openjdk/jdk/commit/60d88b7ae2945724ab4db44207e3390bcff172c0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 15 Apr 2024 and was reviewed by Maurizio Cimadamore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330176](https://bugs.openjdk.org/browse/JDK-8330176) needs maintainer approval

### Issue
 * [JDK-8330176](https://bugs.openjdk.org/browse/JDK-8330176): Typo in Linker javadoc (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/142.diff">https://git.openjdk.org/jdk22u/pull/142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/142#issuecomment-2056982122)