### PR TITLE
8329983: [jdk22u, jdk21u] [arm32] linking with libjvm.so fails after JDK-8142362

### DIFF
--- a/src/hotspot/os_cpu/linux_arm/linux_arm_32.S
+++ b/src/hotspot/os_cpu/linux_arm/linux_arm_32.S
@@ -28,8 +28,6 @@
 	# point or use it in the same manner as does the server
 	# compiler.
 
-        .globl _Copy_conjoint_bytes
-	.type _Copy_conjoint_bytes, %function
         .globl _Copy_arrayof_conjoint_bytes
 	.type _Copy_arrayof_conjoint_bytes, %function
 	.globl _Copy_disjoint_words

--- a/src/hotspot/os_cpu/linux_arm/linux_arm_32.S
+++ b/src/hotspot/os_cpu/linux_arm/linux_arm_32.S
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This is a partial backport of
https://github.com/openjdk/jdk/commit/da14aa463b8fcd56ba1f1a4cdb3e3f7b19f78964. We can  apply changes to lines 31,32 of the original commit to resolve JDK-8329983. The change affects arm32 platform only. 

Additional testing:
- [ ] tier1 tests in debug and release on arm32 (Raspberry PI 5)
- [ ] link and run sample application on armhf:
```
#include <jni.h>

int main(){
    JavaVM *jvm;
    JNIEnv *env; 
    jint res;
    JavaVMInitArgs vm_args; 
    vm_args.version = JNI_VERSION_1_6;
    vm_args.nOptions = 0;
    vm_args.ignoreUnrecognized = false;
    res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
    if (res != JNI_OK) {
       return res;
    }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8329983](https://bugs.openjdk.org/browse/JDK-8329983) needs maintainer approval

### Issue
 * [JDK-8329983](https://bugs.openjdk.org/browse/JDK-8329983): [jdk22u, jdk21u] [arm32] linking with libjvm.so fails after JDK-8142362 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/144.diff">https://git.openjdk.org/jdk22u/pull/144.diff</a>

</details>
