### PR TITLE
8330011: [s390x] update block-comments to make code consistent

### DIFF
--- a/src/hotspot/cpu/s390/upcallLinker_s390.cpp
+++ b/src/hotspot/cpu/s390/upcallLinker_s390.cpp
@@ -63,7 +63,7 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
 
   int offset = reg_save_area_offset;
 
-  __ block_comment("{ preserve_callee_saved_regs ");
+  __ block_comment("preserve_callee_saved_regs {");
   for (int i = 0; i < Register::number_of_registers; i++) {
     Register reg = as_Register(i);
     // Z_SP saved/restored by prologue/epilogue
@@ -82,7 +82,7 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
     }
   }
 
-  __ block_comment("} preserve_callee_saved_regs ");
+  __ block_comment("} preserve_callee_saved_regs");
 }
 
 static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
@@ -92,7 +92,7 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
 
   int offset = reg_save_area_offset;
 
-  __ block_comment("{ restore_callee_saved_regs ");
+  __ block_comment("restore_callee_saved_regs {");
   for (int i = 0; i < Register::number_of_registers; i++) {
     Register reg = as_Register(i);
     // Z_SP saved/restored by prologue/epilogue
@@ -111,7 +111,7 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
     }
   }
 
-  __ block_comment("} restore_callee_saved_regs ");
+  __ block_comment("} restore_callee_saved_regs");
 }
 
 static const int upcall_stub_code_base_size = 1024;
@@ -203,7 +203,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   // Java methods won't preserve them, so save them here:
   preserve_callee_saved_registers(_masm, abi, reg_save_area_offset);
 
-  __ block_comment("{ on_entry");
+  __ block_comment("on_entry {");
   __ load_const_optimized(call_target_address, CAST_FROM_FN_PTR(uint64_t, UpcallLinker::on_entry));
   __ z_aghik(Z_ARG1, Z_SP, frame_data_offset);
   __ load_const_optimized(Z_ARG2, (intptr_t)receiver);
@@ -212,13 +212,13 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ block_comment("} on_entry");
 
   arg_spiller.generate_fill(_masm, arg_save_area_offset);
-  __ block_comment("{ argument shuffle");
+  __ block_comment("argument_shuffle {");
   arg_shuffle.generate(_masm, shuffle_reg, abi._shadow_space_bytes, frame::z_jit_out_preserve_size);
-  __ block_comment("} argument shuffle");
+  __ block_comment("} argument_shuffle");
 
-  __ block_comment("{ receiver ");
+  __ block_comment("receiver {");
   __ get_vm_result(Z_ARG1);
-  __ block_comment("} receiver ");
+  __ block_comment("} receiver");
 
   __ load_const_optimized(Z_method, (intptr_t)entry);
   __ z_stg(Z_method, Address(Z_thread, in_bytes(JavaThread::callee_target_offset())));
@@ -254,7 +254,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 
   result_spiller.generate_spill(_masm, res_save_area_offset);
 
-  __ block_comment("{ on_exit");
+  __ block_comment("on_exit {");
   __ load_const_optimized(call_target_address, CAST_FROM_FN_PTR(uint64_t, UpcallLinker::on_exit));
   __ z_aghik(Z_ARG1, Z_SP, frame_data_offset);
   __ call(call_target_address);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [01bda278](https://github.com/openjdk/jdk/commit/01bda278d6a498ca89c0bc5218680cd51a04e9d3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 17 Apr 2024 and was reviewed by Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330011](https://bugs.openjdk.org/browse/JDK-8330011) needs maintainer approval

### Issue
 * [JDK-8330011](https://bugs.openjdk.org/browse/JDK-8330011): [s390x] update block-comments to make code consistent (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/153.diff">https://git.openjdk.org/jdk22u/pull/153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/153#issuecomment-2063080220)