### PR TITLE
Backport b67b71cd87c62f15d5b73f923c300d0f77c988f5

### DIFF
--- a/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
+++ b/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
@@ -66,7 +66,7 @@ public class StressStackOverflow {
         TestFailureException(String s) { super(s); }
     }
 
-    static final long DURATION_IN_NANOS = Duration.ofMinutes(2).toNanos();
+    static final long DURATION_IN_NANOS = Duration.ofMinutes(1).toNanos();
 
     // Test the ScopedValue recovery mechanism for stack overflows. We implement both Callable
     // and Runnable interfaces. Which one gets tested depends on the constructor argument.

--- a/test/jdk/java/lang/Thread/virtual/StackTraces.java
+++ b/test/jdk/java/lang/Thread/virtual/StackTraces.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @summary Test stack traces in exceptions and stack frames waslked by the StackWalker
+ * @summary Test stack traces in exceptions and stack frames walked by the StackWalker
  *     API do not include the carrier stack frames
  * @requires vm.continuations
  * @modules java.management

--- a/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
@@ -27,7 +27,7 @@
  * @summary Test Thread API with virtual threads
  * @modules java.base/java.lang:+open
  * @library /test/lib
- * @run junit ThreadAPI
+ * @run junit/othervm --enable-native-access=ALL-UNNAMED ThreadAPI
  */
 
 /*
@@ -35,7 +35,8 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open
  * @library /test/lib
- * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations ThreadAPI
+ * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations
+ *     --enable-native-access=ALL-UNNAMED ThreadAPI
  */
 
 import java.time.Duration;
@@ -61,6 +62,7 @@ import java.util.stream.Stream;
 import java.nio.channels.Selector;
 
 import jdk.test.lib.thread.VThreadRunner;
+import jdk.test.lib.thread.VThreadPinner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
@@ -755,11 +757,11 @@ class ThreadAPI {
     void testJoin33() throws Exception {
         AtomicBoolean done = new AtomicBoolean();
         Thread thread = Thread.ofVirtual().start(() -> {
-            synchronized (lock) {
+            VThreadPinner.runPinned(() -> {
                 while (!done.get()) {
                     LockSupport.parkNanos(Duration.ofMillis(20).toNanos());
                 }
-            }
+            });
         });
         try {
             assertFalse(thread.join(Duration.ofMillis(100)));
@@ -1136,7 +1138,7 @@ class ThreadAPI {
     }
 
     /**
-     * Test Thread.yield releases thread when not pinned.
+     * Test Thread.yield releases carrier thread.
      */
     @Test
     void testYield1() throws Exception {
@@ -1164,7 +1166,7 @@ class ThreadAPI {
     }
 
     /**
-     * Test Thread.yield when thread is pinned.
+     * Test Thread.yield when thread is pinned by native frame.
      */
     @Test
     void testYield2() throws Exception {
@@ -1179,10 +1181,10 @@ class ThreadAPI {
                     list.add("B");
                 });
                 child.start();
-                synchronized (lock) {
+                VThreadPinner.runPinned(() -> {
                     Thread.yield();   // pinned so will be a no-op
                     list.add("A");
-                }
+                });
                 try { child.join(); } catch (InterruptedException e) { }
             });
             thread.start();
@@ -1192,7 +1194,7 @@ class ThreadAPI {
     }
 
     /**
-     * Test that Thread.yield does not consume the thread's parking permit.
+     * Test Thread.yield does not consume the thread's parking permit.
      */
     @Test
     void testYield3() throws Exception {
@@ -1205,7 +1207,7 @@ class ThreadAPI {
     }
 
     /**
-     * Test that Thread.yield does not make available the thread's parking permit.
+     * Test Thread.yield does not make available the thread's parking permit.
      */
     @Test
     void testYield4() throws Exception {
@@ -1406,11 +1408,9 @@ class ThreadAPI {
      */
     @Test
     void testSleep8() throws Exception {
-        VThreadRunner.run(() -> {
+        VThreadPinner.runPinned(() -> {
             long start = millisTime();
-            synchronized (lock) {
-                Thread.sleep(1000);
-            }
+            Thread.sleep(1000);
             expectDuration(start, /*min*/900, /*max*/20_000);
         });
     }
@@ -1424,9 +1424,9 @@ class ThreadAPI {
             Thread me = Thread.currentThread();
             me.interrupt();
             try {
-                synchronized (lock) {
+                VThreadPinner.runPinned(() -> {
                     Thread.sleep(2000);
-                }
+                });
                 fail("sleep not interrupted");
             } catch (InterruptedException e) {
                 // expected
@@ -1444,9 +1444,9 @@ class ThreadAPI {
             Thread t = Thread.currentThread();
             scheduleInterrupt(t, 100);
             try {
-                synchronized (lock) {
+                VThreadPinner.runPinned(() -> {
                     Thread.sleep(20 * 1000);
-                }
+                });
                 fail("sleep not interrupted");
             } catch (InterruptedException e) {
                 // interrupt status should be cleared
@@ -1579,8 +1579,7 @@ class ThreadAPI {
     @Test
     void testUncaughtExceptionHandler1() throws Exception {
         class FooException extends RuntimeException { }
-        var exception = new AtomicReference<Throwable>();
-        Thread.UncaughtExceptionHandler handler = (thread, exc) -> exception.set(exc);
+        var handler = new CapturingUHE();
         Thread thread = Thread.ofVirtual().start(() -> {
             Thread me = Thread.currentThread();
             assertTrue(me.getUncaughtExceptionHandler() == me.getThreadGroup());
@@ -1589,7 +1588,8 @@ class ThreadAPI {
             throw new FooException();
         });
         thread.join();
-        assertTrue(exception.get() instanceof FooException);
+        assertInstanceOf(FooException.class, handler.exception());
+        assertEquals(thread, handler.thread());
         assertNull(thread.getUncaughtExceptionHandler());
     }
 
@@ -1599,8 +1599,7 @@ class ThreadAPI {
     @Test
     void testUncaughtExceptionHandler2() throws Exception {
         class FooException extends RuntimeException { }
-        var exception = new AtomicReference<Throwable>();
-        Thread.UncaughtExceptionHandler handler = (thread, exc) -> exception.set(exc);
+        var handler = new CapturingUHE();
         Thread.UncaughtExceptionHandler savedHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(handler);
         Thread thread;
@@ -1611,23 +1610,59 @@ class ThreadAPI {
             });
             thread.join();
         } finally {
-            Thread.setDefaultUncaughtExceptionHandler(savedHandler);
+            Thread.setDefaultUncaughtExceptionHandler(savedHandler);  // restore
         }
-        assertTrue(exception.get() instanceof FooException);
+        assertInstanceOf(FooException.class, handler.exception());
+        assertEquals(thread, handler.thread());
         assertNull(thread.getUncaughtExceptionHandler());
     }
 
     /**
-     * Test no UncaughtExceptionHandler set.
+     * Test Thread and default UncaughtExceptionHandler set.
      */
     @Test
     void testUncaughtExceptionHandler3() throws Exception {
         class FooException extends RuntimeException { }
-        Thread thread = Thread.ofVirtual().start(() -> {
-            throw new FooException();
-        });
-        thread.join();
+        var defaultHandler = new CapturingUHE();
+        var threadHandler = new CapturingUHE();
+        Thread.UncaughtExceptionHandler savedHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler(defaultHandler);
+        Thread thread;
+        try {
+            thread = Thread.ofVirtual().start(() -> {
+                Thread me = Thread.currentThread();
+                assertTrue(me.getUncaughtExceptionHandler() == me.getThreadGroup());
+                me.setUncaughtExceptionHandler(threadHandler);
+                assertTrue(me.getUncaughtExceptionHandler() == threadHandler);
+                throw new FooException();
+            });
+            thread.join();
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(savedHandler);  // restore
+        }
+        assertInstanceOf(FooException.class, threadHandler.exception());
+        assertNull(defaultHandler.exception());
+        assertEquals(thread, threadHandler.thread());
         assertNull(thread.getUncaughtExceptionHandler());
+    }
+
+    /**
+     * Test no Thread or default UncaughtExceptionHandler set.
+     */
+    @Test
+    void testUncaughtExceptionHandler4() throws Exception {
+        Thread.UncaughtExceptionHandler savedHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler(null);
+        try {
+            class FooException extends RuntimeException { }
+            Thread thread = Thread.ofVirtual().start(() -> {
+                throw new FooException();
+            });
+            thread.join();
+            assertNull(thread.getUncaughtExceptionHandler());
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(savedHandler);
+        }
     }
 
     /**
@@ -2064,10 +2099,76 @@ class ThreadAPI {
     }
 
     /**
-     * Test Thread::getStackTrace on terminated thread.
+     * Test Thread::getStackTrace on timed-parked thread.
      */
     @Test
     void testGetStackTrace6() throws Exception {
+        var thread = Thread.ofVirtual().start(() -> {
+            LockSupport.parkNanos(Long.MAX_VALUE);
+        });
+        await(thread, Thread.State.TIMED_WAITING);
+        try {
+            StackTraceElement[] stack = thread.getStackTrace();
+            assertTrue(contains(stack, "LockSupport.parkNanos"));
+        } finally {
+            LockSupport.unpark(thread);
+            thread.join();
+        }
+    }
+
+    /**
+     * Test Thread::getStackTrace on parked thread that is pinned.
+     */
+    @Test
+    void testGetStackTrace7() throws Exception {
+        AtomicBoolean done = new AtomicBoolean();
+        var thread = Thread.ofVirtual().start(() -> {
+            VThreadPinner.runPinned(() -> {
+                while (!done.get()) {
+                    LockSupport.park();
+                }
+            });
+        });
+        await(thread, Thread.State.WAITING);
+        try {
+            StackTraceElement[] stack = thread.getStackTrace();
+            assertTrue(contains(stack, "LockSupport.park"));
+        } finally {
+            done.set(true);
+            LockSupport.unpark(thread);
+            thread.join();
+        }
+    }
+
+    /**
+     * Test Thread::getStackTrace on timed-parked thread that is pinned.
+     */
+    @Test
+    void testGetStackTrace8() throws Exception {
+        AtomicBoolean done = new AtomicBoolean();
+        var thread = Thread.ofVirtual().start(() -> {
+            VThreadPinner.runPinned(() -> {
+                while (!done.get()) {
+                    LockSupport.parkNanos(Long.MAX_VALUE);
+                }
+            });
+        });
+        await(thread, Thread.State.TIMED_WAITING);
+        try {
+            StackTraceElement[] stack = thread.getStackTrace();
+            assertTrue(contains(stack, "LockSupport.parkNanos"));
+        } finally {
+            done.set(true);
+            LockSupport.unpark(thread);
+            thread.join();
+        }
+    }
+
+    /**
+     * Test Thread::getStackTrace on terminated thread.
+     */
+    @Test
+    void testGetStackTrace9() throws Exception {
         var thread = Thread.ofVirtual().start(() -> { });
         thread.join();
         StackTraceElement[] stack = thread.getStackTrace();
@@ -2234,7 +2335,7 @@ class ThreadAPI {
             ThreadGroup vgroup = Thread.currentThread().getThreadGroup();
             Thread[] threads = new Thread[100];
             int n = vgroup.enumerate(threads, /*recurse*/false);
-            assertTrue(n == 0);
+            assertFalse(Arrays.stream(threads, 0, n).anyMatch(Thread::isVirtual));
         });
     }
 
@@ -2345,6 +2446,33 @@ class ThreadAPI {
         });
         thread.join();
         assertTrue(thread.toString().contains("fred"));
+    }
+
+    /**
+     * Thread.UncaughtExceptionHandler that captures the first exception thrown.
+     */
+    private static class CapturingUHE implements Thread.UncaughtExceptionHandler {
+        Thread thread;
+        Throwable exception;
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+            synchronized (this) {
+                if (thread == null) {
+                    this.thread = t;
+                    this.exception = e;
+                }
+            }
+        }
+        Thread thread() {
+            synchronized (this) {
+                return thread;
+            }
+        }
+        Throwable exception() {
+            synchronized (this) {
+                return exception;
+            }
+        }
     }
 
     /**

--- a/test/jdk/java/lang/Thread/virtual/stress/PinALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/PinALot.java
@@ -25,13 +25,15 @@
  * @test
  * @summary Stress test timed park when pinned
  * @requires vm.debug != true
- * @run main PinALot 500000
+ * @library /test/lib
+ * @run main/othervm --enable-native-access=ALL-UNNAMED PinALot 500000
  */
 
 /*
  * @test
  * @requires vm.debug == true
- * @run main/othervm/timeout=300 PinALot 200000
+ * @library /test/lib
+ * @run main/othervm/timeout=300 --enable-native-access=ALL-UNNAMED PinALot 200000
  */
 
 import java.time.Duration;
@@ -39,9 +41,9 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
-public class PinALot {
+import jdk.test.lib.thread.VThreadPinner;
 
-    static final Object lock = new Object();
+public class PinALot {
 
     public static void main(String[] args) throws Exception {
         int iterations = 1_000_000;
@@ -53,11 +55,11 @@ public class PinALot {
         AtomicInteger count = new AtomicInteger();
 
         Thread thread = Thread.ofVirtual().start(() -> {
-            synchronized (lock) {
+            VThreadPinner.runPinned(() -> {
                 while (count.incrementAndGet() < ITERATIONS) {
                     LockSupport.parkNanos(1);
                 }
-            }
+            });
         });
 
         boolean terminated;

--- a/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
@@ -26,7 +26,7 @@
  * @summary Stress test virtual threads with a variation of the Skynet 1M benchmark
  * @requires vm.continuations
  * @requires !vm.debug | vm.gc != "Z"
- * @run main/othervm/timeout=300 -Xmx1g Skynet
+ * @run main/othervm/timeout=300 -Xmx1500m Skynet
  */
 
 /*
@@ -35,7 +35,7 @@
  * @requires vm.gc.ZSinglegen
  * @run main/othervm/timeout=300 -XX:+UnlockDiagnosticVMOptions
  *     -XX:+UseZGC -XX:-ZGenerational
- *     -XX:+ZVerifyOops -XX:ZCollectionInterval=0.01 -Xmx1g Skynet
+ *     -XX:+ZVerifyOops -XX:ZCollectionInterval=0.01 -Xmx1500m Skynet
  */
 
 /*
@@ -44,7 +44,7 @@
  * @requires vm.gc.ZGenerational
  * @run main/othervm/timeout=300 -XX:+UnlockDiagnosticVMOptions
  *     -XX:+UseZGC -XX:+ZGenerational
- *     -XX:+ZVerifyOops -XX:ZCollectionInterval=0.01 -Xmx1g Skynet
+ *     -XX:+ZVerifyOops -XX:ZCollectionInterval=0.01 -Xmx1500m Skynet
  */
 
 import java.util.concurrent.BlockingQueue;

--- a/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
+++ b/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -411,9 +411,7 @@ public class SelectWithConsumer {
         // select(Consumer, timeout)
         try (Selector sel = Selector.open()) {
             scheduleInterrupt(Thread.currentThread(), 1, SECONDS);
-            long start = System.currentTimeMillis();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            long duration = System.currentTimeMillis() - start;
             assertTrue(n == 0);
             assertTrue(Thread.currentThread().isInterrupted());
             assertTrue(sel.isOpen());

--- a/test/lib/jdk/test/lib/thread/VThreadPinner.java
+++ b/test/lib/jdk/test/lib/thread/VThreadPinner.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.thread;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import jdk.test.lib.thread.VThreadRunner.ThrowingRunnable;
+
+/**
+ * Helper class to allow tests run a task in a virtual thread while pinning its carrier.
+ *
+ * It defines the {@code runPinned} method to run a task with a native frame on the stack.
+ */
+public class VThreadPinner {
+    private static final Path JAVA_LIBRARY_PATH = Path.of(System.getProperty("java.library.path"));
+    private static final Path LIB_PATH = JAVA_LIBRARY_PATH.resolve(System.mapLibraryName("VThreadPinner"));
+
+    // method handle to call the native function
+    private static final MethodHandle INVOKER = invoker();
+
+    // function pointer to call
+    private static final MemorySegment UPCALL_STUB = upcallStub();
+
+    /**
+     * Thread local with the task to run.
+     */
+    private static final ThreadLocal<TaskRunner> TASK_RUNNER = new ThreadLocal<>();
+
+    /**
+     * Runs a task, capturing any exception or error thrown.
+     */
+    private static class TaskRunner implements Runnable {
+        private final ThrowingRunnable<?> task;
+        private Throwable throwable;
+
+        TaskRunner(ThrowingRunnable<?> task) {
+            this.task = task;
+        }
+
+        @Override
+        public void run() {
+            try {
+                task.run();
+            } catch (Throwable ex) {
+                throwable = ex;
+            }
+        }
+
+        Throwable exception() {
+            return throwable;
+        }
+    }
+
+    /**
+     * Called by the native function to run the task stashed in the thread local. The
+     * task runs with the native frame on the stack.
+     */
+    private static void callback() {
+        TASK_RUNNER.get().run();
+    }
+
+    /**
+     * Runs the given task on a virtual thread pinned to its carrier. If called from a
+     * virtual thread then it invokes the task directly.
+     */
+    public static <X extends Throwable> void runPinned(ThrowingRunnable<X> task) throws X {
+        if (!Thread.currentThread().isVirtual()) {
+            VThreadRunner.run(() -> runPinned(task));
+            return;
+        }
+        var runner = new TaskRunner(task);
+        TASK_RUNNER.set(runner);
+        try {
+            INVOKER.invoke(UPCALL_STUB);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            TASK_RUNNER.remove();
+        }
+        Throwable ex = runner.exception();
+        if (ex != null) {
+            if (ex instanceof RuntimeException e)
+                throw e;
+            if (ex instanceof Error e)
+                throw e;
+            throw (X) ex;
+        }
+    }
+
+    /**
+     * Returns a method handle to the native function void call(void *(*f)(void *)).
+     */
+    @SuppressWarnings("restricted")
+    private static MethodHandle invoker() {
+        Linker abi = Linker.nativeLinker();
+        try {
+            SymbolLookup lib = SymbolLookup.libraryLookup(LIB_PATH, Arena.global());
+            MemorySegment symbol = lib.find("call").orElseThrow();
+            FunctionDescriptor desc = FunctionDescriptor.ofVoid(ValueLayout.ADDRESS);
+            return abi.downcallHandle(symbol, desc);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns an upcall stub to use as a function pointer to invoke the callback method.
+     */
+    @SuppressWarnings("restricted")
+    private static MemorySegment upcallStub() {
+        Linker abi = Linker.nativeLinker();
+        try {
+            MethodHandle callback = MethodHandles.lookup()
+                    .findStatic(VThreadPinner.class, "callback", MethodType.methodType(void.class));
+            return abi.upcallStub(callback, FunctionDescriptor.ofVoid(), Arena.global());
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/thread/VThreadRunner.java
+++ b/test/lib/jdk/test/lib/thread/VThreadRunner.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Helper class to support tests running tasks a in virtual thread.
+ * Helper class to support tests running tasks in a virtual thread.
  */
 public class VThreadRunner {
     private VThreadRunner() { }
@@ -41,38 +41,31 @@ public class VThreadRunner {
     public static final int NO_INHERIT_THREAD_LOCALS = 1 << 2;
 
     /**
-     * Represents a task that does not return a result but may throw
-     * an exception.
+     * Represents a task that does not return a result but may throw an exception.
      */
     @FunctionalInterface
-    public interface ThrowingRunnable {
-        /**
-         * Runs this operation.
-         */
-        void run() throws Exception;
+    public interface ThrowingRunnable<X extends Throwable> {
+        void run() throws X;
     }
 
     /**
      * Run a task in a virtual thread and wait for it to terminate.
      * If the task completes with an exception then it is thrown by this method.
-     * If the task throws an Error then it is wrapped in an RuntimeException.
      *
      * @param name thread name, can be null
      * @param characteristics thread characteristics
      * @param task the task to run
-     * @throws Exception the exception thrown by the task
+     * @throws X the exception thrown by the task
      */
-    public static void run(String name,
-                           int characteristics,
-                           ThrowingRunnable task) throws Exception {
-        AtomicReference<Exception> exc = new AtomicReference<>();
-        Runnable target =  () -> {
+    public static <X extends Throwable> void run(String name,
+                                                 int characteristics,
+                                                 ThrowingRunnable<X> task) throws X {
+        var throwableRef = new AtomicReference<Throwable>();
+        Runnable target = () -> {
             try {
                 task.run();
-            } catch (Error e) {
-                exc.set(new RuntimeException(e));
-            } catch (Exception e) {
-                exc.set(e);
+            } catch (Throwable ex) {
+                throwableRef.set(ex);
             }
         };
 
@@ -84,54 +77,59 @@ public class VThreadRunner {
         Thread thread = builder.start(target);
 
         // wait for thread to terminate
-        while (thread.join(Duration.ofSeconds(10)) == false) {
-            System.out.println("-- " + thread + " --");
-            for (StackTraceElement e : thread.getStackTrace()) {
-                System.out.println("  " + e);
+        try {
+            while (thread.join(Duration.ofSeconds(10)) == false) {
+                System.out.println("-- " + thread + " --");
+                for (StackTraceElement e : thread.getStackTrace()) {
+                    System.out.println("  " + e);
+                }
             }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
 
-        Exception e = exc.get();
-        if (e != null) {
-            throw e;
+        Throwable ex = throwableRef.get();
+        if (ex != null) {
+            if (ex instanceof RuntimeException e)
+                throw e;
+            if (ex instanceof Error e)
+                throw e;
+            throw (X) ex;
         }
     }
 
     /**
      * Run a task in a virtual thread and wait for it to terminate.
      * If the task completes with an exception then it is thrown by this method.
-     * If the task throws an Error then it is wrapped in an RuntimeException.
      *
      * @param name thread name, can be null
      * @param task the task to run
-     * @throws Exception the exception thrown by the task
+     * @throws X the exception thrown by the task
      */
-    public static void run(String name, ThrowingRunnable task) throws Exception {
+    public static <X extends Throwable> void run(String name, ThrowingRunnable<X> task) throws X {
         run(name, 0, task);
     }
 
     /**
      * Run a task in a virtual thread and wait for it to terminate.
      * If the task completes with an exception then it is thrown by this method.
-     * If the task throws an Error then it is wrapped in an RuntimeException.
      *
      * @param characteristics thread characteristics
      * @param task the task to run
-     * @throws Exception the exception thrown by the task
+     * @throws X the exception thrown by the task
      */
-    public static void run(int characteristics, ThrowingRunnable task) throws Exception {
+    public static <X extends Throwable> void run(int characteristics, ThrowingRunnable<X> task) throws X {
         run(null, characteristics, task);
     }
 
     /**
      * Run a task in a virtual thread and wait for it to terminate.
      * If the task completes with an exception then it is thrown by this method.
-     * If the task throws an Error then it is wrapped in an RuntimeException.
      *
      * @param task the task to run
-     * @throws Exception the exception thrown by the task
+     * @throws X the exception thrown by the task
      */
-    public static void run(ThrowingRunnable task) throws Exception {
+    public static <X extends Throwable> void run(ThrowingRunnable<X> task) throws X {
         run(null, 0, task);
     }
 

--- a/test/lib/jdk/test/lib/thread/libVThreadPinner.c
+++ b/test/lib/jdk/test/lib/thread/libVThreadPinner.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+/*
+ * Call a function with the given function pointer.
+ */
+EXPORT void call(void *(*f)(void)) {
+    (*f)();
+}


### PR DESCRIPTION
Test-only backport that simplifies Loom maintenance. This would make subsequent backports clean.

Additional testing:
 - [ ] MacOS AArch64 server fastdebug, `jdk_loom hotspot_loom`