### PR TITLE
8328168: Epsilon: Premature OOM when allocating object larger than uncommitted heap size

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestEnoughUnusedSpace.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestEnoughUnusedSpace.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package gc.epsilon;
+
+/**
+ * @test TestEnoughUnusedSpace
+ * @requires vm.gc.Epsilon
+ * @summary Epsilon should allocates object successfully if it has enough space.
+ * @run main/othervm -Xms64M -Xmx128M -XX:+UnlockExperimentalVMOptions
+ *                   -XX:+UseEpsilonGC gc.epsilon.TestEnoughUnusedSpace
+ */
+
+public class TestEnoughUnusedSpace {
+    static volatile Object arr;
+
+    public static void main(String[] args) {
+        // Create an array about 90M. It should be created successfully
+        // instead of throwing OOME, because 90M is smaller than 128M.
+        arr = new byte[90 * 1024 * 1024];
+    }
+}


### PR DESCRIPTION
Fixes Epsilon performance problem, corner-case with clear test.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, new regression test fails without the patch, passes with it
 - [x] MacOS AArch64 server fastdebug, `gc/epsilon`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328168](https://bugs.openjdk.org/browse/JDK-8328168) needs maintainer approval

### Issue
 * [JDK-8328168](https://bugs.openjdk.org/browse/JDK-8328168): Epsilon: Premature OOM when allocating object larger than uncommitted heap size (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/163.diff">https://git.openjdk.org/jdk22u/pull/163.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/163#issuecomment-2073231507)