### PR TITLE
8330094: RISC-V: Save and restore FRM in the call stub

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -131,7 +131,7 @@
     // Entry frames
     // n.b. these values are determined by the layout defined in
     // stubGenerator for the Java call stub
-    entry_frame_after_call_words                     =  34,
+    entry_frame_after_call_words                     =  35,
     entry_frame_call_wrapper_offset                  = -10,
 
     // we don't need a save area

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3000,7 +3000,6 @@ instruct vloadcon(vReg dst, immI0 src) %{
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($dst$$reg));
     if (is_floating_point_type(bt)) {
-      __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
       __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     }
   %}
@@ -3214,7 +3213,6 @@ instruct vcvtBtoX(vReg dst, vReg src) %{
     if (is_floating_point_type(bt)) {
       __ integer_extend_v(as_VectorRegister($dst$$reg), bt == T_FLOAT ? T_INT : T_LONG,
                           Matcher::vector_length(this), as_VectorRegister($src$$reg), T_BYTE);
-      __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
       __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     } else {
       __ integer_extend_v(as_VectorRegister($dst$$reg), bt, 
@@ -3261,7 +3259,6 @@ instruct vcvtStoX_fp_extend(vReg dst, vReg src) %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), (bt == T_FLOAT ? T_INT : T_LONG),
                         Matcher::vector_length(this), as_VectorRegister($src$$reg), T_SHORT);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
     __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3300,7 +3297,6 @@ instruct vcvtItoF(vReg dst, vReg src) %{
   format %{ "vcvtItoF $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
-    __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
     __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3313,7 +3309,6 @@ instruct vcvtItoD(vReg dst, vReg src) %{
   format %{ "vcvtItoD $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mf2);
-    __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
     __ vfwcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3341,7 +3336,6 @@ instruct vcvtLtoF(vReg dst, vReg src) %{
   format %{ "vcvtLtoF $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
-    __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
     __ vfncvt_f_x_w(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3353,7 +3347,6 @@ instruct vcvtLtoD(vReg dst, vReg src) %{
   format %{ "vcvtLtoD $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
-    __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
     __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3411,7 +3404,6 @@ instruct vcvtFtoD(vReg dst, vReg src) %{
   format %{ "vcvtFtoD $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
-    __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
     __ vfwcvt_f_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3459,7 +3451,6 @@ instruct vcvtDtoF(vReg dst, vReg src) %{
   format %{ "vcvtDtoF $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
-    __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
     __ vfncvt_f_f_w(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -127,8 +127,9 @@ class StubGenerator: public StubCodeGenerator {
   //     [ return_from_Java     ] <--- sp
   //     [ argument word n      ]
   //      ...
-  // -34 [ argument word 1      ]
-  // -33 [ saved f27            ] <--- sp_after_call
+  // -35 [ argument word 1      ]
+  // -34 [ saved FRM in Floating-point Control and Status Register ] <--- sp_after_call
+  // -33 [ saved f27            ]
   // -32 [ saved f26            ]
   // -31 [ saved f25            ]
   // -30 [ saved f24            ]
@@ -165,8 +166,9 @@ class StubGenerator: public StubCodeGenerator {
 
   // Call stub stack layout word offsets from fp
   enum call_stub_layout {
-    sp_after_call_off  = -33,
+    sp_after_call_off  = -34,
 
+    frm_off            = sp_after_call_off,
     f27_off            = -33,
     f26_off            = -32,
     f25_off            = -31,
@@ -214,6 +216,7 @@ class StubGenerator: public StubCodeGenerator {
 
     const Address sp_after_call (fp, sp_after_call_off  * wordSize);
 
+    const Address frm_save      (fp, frm_off            * wordSize);
     const Address call_wrapper  (fp, call_wrapper_off   * wordSize);
     const Address result        (fp, result_off         * wordSize);
     const Address result_type   (fp, result_type_off    * wordSize);
@@ -295,6 +298,16 @@ class StubGenerator: public StubCodeGenerator {
     __ fsd(f25, f25_save);
     __ fsd(f26, f26_save);
     __ fsd(f27, f27_save);
+
+    __ frrm(t0);
+    __ sd(t0, frm_save);
+    // Set frm to the state we need. We do want Round to Nearest. We
+    // don't want non-IEEE rounding modes.
+    Label skip_fsrmi;
+    guarantee(__ RoundingMode::rne == 0, "must be");
+    __ beqz(t0, skip_fsrmi);
+    __ fsrmi(__ RoundingMode::rne);
+    __ bind(skip_fsrmi);
 
     // install Java thread in global register now we have saved
     // whatever value it held
@@ -414,6 +427,14 @@ class StubGenerator: public StubCodeGenerator {
     __ ld(x18, x18_save);
 
     __ ld(x9, x9_save);
+
+    // restore frm
+    Label skip_fsrm;
+    __ ld(t0, frm_save);
+    __ frrm(t1);
+    __ beq(t0, t1, skip_fsrm);
+    __ fsrm(t0);
+    __ bind(skip_fsrm);
 
     __ ld(c_rarg0, call_wrapper);
     __ ld(c_rarg1, result);


### PR DESCRIPTION
Hi, The same issue also exists in jdk22u. So I would like to backport [JDK-8330094](https://bugs.openjdk.org/browse/JDK-8330094) to jdk22u. With this change, we save and restore the default floating-point control state when we enter and leave Java code, ensuring that we are still Java compatible if we're called via the JNI invocation interface with a weird FP control state. RISC-V specific change, risk is low.
The backport is not clean because jdk22u has no [JDK-8321021](https://bugs.openjdk.org/browse/JDK-8321021)

### Testing

- [x]  Run tier1-3 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330094](https://bugs.openjdk.org/browse/JDK-8330094) needs maintainer approval

### Issue
 * [JDK-8330094](https://bugs.openjdk.org/browse/JDK-8330094): RISC-V: Save and restore FRM in the call stub (**Enhancement** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/174.diff">https://git.openjdk.org/jdk22u/pull/174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/174#issuecomment-2085340486)