### PR TITLE
Backport 747582484ce89e16661ef917a89adb52f5adc2e6

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -664,7 +664,7 @@ javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
-javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8320944 windows-all
+javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8327236 windows-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all


### PR DESCRIPTION
Backporting [JDK-8329510](https://bugs.openjdk.org/browse/JDK-8329510) which updates the bugid under which `javax/swing/JFileChooser/8194044/FileSystemRootTest.java` is problem-listed.