### PR TITLE
8328822: C2: "negative trip count?" assert failure in profile predicate code

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -956,7 +956,7 @@ bool PhaseIdealLoop::loop_predication_should_follow_branches(IdealLoopTree* loop
         CountedLoopNode* cl = head->as_CountedLoop();
         if (cl->phi() != nullptr) {
           const TypeInt* t = _igvn.type(cl->phi())->is_int();
-          float worst_case_trip_cnt = ((float)t->_hi - t->_lo) / ABS(cl->stride_con());
+          float worst_case_trip_cnt = ((float)t->_hi - t->_lo) / ABS((float)cl->stride_con());
           if (worst_case_trip_cnt < loop_trip_cnt) {
             loop_trip_cnt = worst_case_trip_cnt;
           }

--- a/test/hotspot/jtreg/compiler/predicates/TestCountedLoopMinJintStride.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestCountedLoopMinJintStride.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8328822
+ * @summary C2: "negative trip count?" assert failure in profile predicate code
+ * @run main/othervm  -XX:-BackgroundCompilation TestCountedLoopMinJintStride
+ */
+
+import java.util.Objects;
+
+public class TestCountedLoopMinJintStride {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1(Integer.MAX_VALUE-1, Integer.MAX_VALUE, 0);
+            testHelper1(100, -1, Integer.MAX_VALUE, 0);
+            test2(Integer.MAX_VALUE-1, Integer.MAX_VALUE, 0);
+            testHelper2(100, -1, Integer.MAX_VALUE, 0);
+        }
+    }
+
+    private static void test1(int stop, int range, int start) {
+        testHelper1(stop, Integer.MIN_VALUE, range, start);
+    }
+
+    private static void testHelper1(int stop, int stride, int range, int start) {
+        for (int i = stop; i >= start; i += stride) {
+            Objects.checkIndex(i, range);
+        }
+    }
+
+    private static void test2(int stop, int range, int start) {
+        testHelper1(stop, Integer.MIN_VALUE, range, start);
+    }
+
+    private static void testHelper2(int stop, int stride, int range, int start) {
+        for (int i = stop; i >= start; i += stride) {
+            if (i < 0 || i >= range) {
+                throw new RuntimeException("out of bounds");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simple corner case fix in C2.

Additional testing:
  - [x] New regression test fails without the fix, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328822](https://bugs.openjdk.org/browse/JDK-8328822) needs maintainer approval

### Issue
 * [JDK-8328822](https://bugs.openjdk.org/browse/JDK-8328822): C2: "negative trip count?" assert failure in profile predicate code (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/179.diff">https://git.openjdk.org/jdk22u/pull/179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/179#issuecomment-2090403518)