### PR TITLE
8331164: createJMHBundle.sh download jars fail when url needed to be redirected

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -43,7 +43,7 @@ rm -f *
 fetchJar() {
   url="https://repo.maven.apache.org/maven2/$1/$2/$3/$2-$3.jar"
   if command -v curl > /dev/null; then
-      curl -O --fail $url
+      curl -OL --fail $url
   elif command -v wget > /dev/null; then
       wget $url
   else


### PR DESCRIPTION
Hi,
This is clean backport of JDK-8331164, to fixed download failure when the URL needed to be redirected.
Only change devkit shell script, the risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8331164](https://bugs.openjdk.org/browse/JDK-8331164) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331164](https://bugs.openjdk.org/browse/JDK-8331164): createJMHBundle.sh download jars fail when url needed to be redirected (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/180.diff">https://git.openjdk.org/jdk22u/pull/180.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/180#issuecomment-2090583723)