### PR TITLE
8330748: ByteArrayOutputStream.writeTo(OutputStream) pins carrier

### DIFF
--- a/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,8 +159,16 @@ public class ByteArrayOutputStream extends OutputStream {
      * @throws  NullPointerException if {@code out} is {@code null}.
      * @throws  IOException if an I/O error occurs.
      */
-    public synchronized void writeTo(OutputStream out) throws IOException {
-        out.write(buf, 0, count);
+    public void writeTo(OutputStream out) throws IOException {
+        if (Thread.currentThread().isVirtual()) {
+            byte[] bytes;
+            synchronized (this) {
+                bytes = Arrays.copyOf(buf, count);
+            }
+            out.write(bytes);
+        } else synchronized (this) {
+            out.write(buf, 0, count);
+        }
     }
 
     /**

--- a/test/jdk/java/io/ByteArrayOutputStream/WriteToReleasesCarrier.java
+++ b/test/jdk/java/io/ByteArrayOutputStream/WriteToReleasesCarrier.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8330748
+ * @summary Test ByteArrayOutputStream.writeTo releases carrier thread
+ * @requires vm.continuations
+ * @modules java.base/java.lang:+open
+ * @run main WriteToReleasesCarrier
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+public class WriteToReleasesCarrier {
+    public static void main(String[] args) throws Exception {
+        byte[] bytes = "Hello".getBytes(StandardCharsets.UTF_8);
+
+        var baos = new ByteArrayOutputStream();
+        baos.write(bytes);
+
+        var target = new ParkingOutputStream();
+
+        try (ExecutorService scheduler = Executors.newFixedThreadPool(1)) {
+            Thread.Builder builder = virtualThreadBuilder(scheduler);
+            var started = new CountDownLatch(1);
+            var vthread1 = builder.start(() -> {
+                started.countDown();
+                try {
+                    baos.writeTo(target);
+                } catch (IOException ioe) { }
+            });
+            try {
+                started.await();
+                await(vthread1, Thread.State.WAITING);
+
+                // carrier should be released, use it for another thread
+                var executed = new AtomicBoolean();
+                var vthread2 = builder.start(() -> {
+                    executed.set(true);
+                });
+                vthread2.join();
+                if (!executed.get()) {
+                    throw new RuntimeException("Second virtual thread did not run");
+                }
+            } finally {
+                LockSupport.unpark(vthread1);
+                vthread1.join();
+            }
+        }
+
+        if (!Arrays.equals(target.toByteArray(), bytes)) {
+            throw new RuntimeException("Expected bytes not written");
+        }
+    }
+
+    /**
+     * Waits for a thread to get to the expected state.
+     */
+    private static void await(Thread thread, Thread.State expectedState) throws Exception {
+        Thread.State state = thread.getState();
+        while (state != expectedState) {
+            Thread.sleep(10);
+            state = thread.getState();
+        }
+    }
+
+    /**
+     * An OutputStream that parks when writing.
+     */
+    static class ParkingOutputStream extends OutputStream {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        @Override
+        public void write(int i) {
+            LockSupport.park();
+            baos.write(i);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            LockSupport.park();
+            baos.write(b, off, len);
+        }
+
+        byte[] toByteArray() {
+            return baos.toByteArray();
+        }
+    }
+
+    /**
+     * Returns a builder to create virtual threads that use the given scheduler.
+     */
+    static Thread.Builder.OfVirtual virtualThreadBuilder(Executor scheduler) throws Exception {
+        Class<?> clazz = Class.forName("java.lang.ThreadBuilders$VirtualThreadBuilder");
+        Constructor<?> ctor = clazz.getDeclaredConstructor(Executor.class);
+        ctor.setAccessible(true);
+        return (Thread.Builder.OfVirtual) ctor.newInstance(scheduler);
+    }
+}


### PR DESCRIPTION
clean backport of https://github.com/openjdk/jdk/commit/819f3d6fc70ff6fe54ac5f9033c17c3dd4326aa5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8330748](https://bugs.openjdk.org/browse/JDK-8330748) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330748](https://bugs.openjdk.org/browse/JDK-8330748): ByteArrayOutputStream.writeTo(OutputStream) pins carrier (**Enhancement** - P4 - Approved)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Sean Coffey](https://openjdk.org/census#coffeys) - **Reviewer** ⚠️ Added manually
 * [Jaikiran Pai](https://openjdk.org/census#jpai) - no project role ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/182/head:pull/182` \
`$ git checkout pull/182`

Update a local copy of the PR: \
`$ git checkout pull/182` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 182`

View PR using the GUI difftool: \
`$ git pr show -t 182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/182.diff">https://git.openjdk.org/jdk22u/pull/182.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/182#issuecomment-2092665343)