### PR TITLE
8331331: :tier1 target explanation in doc/testing.md is incorrect

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -179,8 +179,9 @@ more tab-completion friendly. For more complex test runs, the
 <p>The test specifications given in <code>TEST</code> is parsed into
 fully qualified test descriptors, which clearly and unambigously show
 which tests will be run. As an example, <code>:tier1</code> will expand
-to
-<code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 jtreg:$(TOPDIR)/test/nashorn:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1</code>.
+to include all subcomponent test directories that define `tier1`,
+for example:
+<code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 ...</code>.
 You can always submit a list of fully qualified test descriptors in the
 <code>TEST</code> variable if you want to shortcut the parser.</p>
 <h3 id="common-test-groups">Common Test Groups</h3>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -103,11 +103,11 @@ test runs, the `test TEST="x"` solution needs to be used.
 
 The test specifications given in `TEST` is parsed into fully qualified test
 descriptors, which clearly and unambigously show which tests will be run. As an
-example, `:tier1` will expand to `jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1
-jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1
-jtreg:$(TOPDIR)/test/nashorn:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1`. You can
-always submit a list of fully qualified test descriptors in the `TEST` variable
-if you want to shortcut the parser.
+example, `:tier1` will expand to include all subcomponent test directories
+that define `tier1`, for example: `jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1
+jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 ...`. You
+can always submit a list of fully qualified test descriptors in the `TEST`
+variable if you want to shortcut the parser.
 
 ### Common Test Groups
 


### PR DESCRIPTION
Hi,
  This is clean backport of [JDK-8331331](https://bugs.openjdk.org/browse/JDK-8331331), fixed the incorrect explanation :tier1 target in doc/testing.md. No risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331331](https://bugs.openjdk.org/browse/JDK-8331331) needs maintainer approval

### Issue
 * [JDK-8331331](https://bugs.openjdk.org/browse/JDK-8331331): :tier1 target explanation in doc/testing.md is incorrect (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/183/head:pull/183` \
`$ git checkout pull/183`

Update a local copy of the PR: \
`$ git checkout pull/183` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 183`

View PR using the GUI difftool: \
`$ git pr show -t 183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/183.diff">https://git.openjdk.org/jdk22u/pull/183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/183#issuecomment-2093324195)