### PR TITLE
8331894: [jdk22] compiler/print/CompileCommandMemLimit.java fails after backporting JDK-8325095

### DIFF
--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -405,7 +405,7 @@ void CompilationMemoryStatistic::on_end_compilation() {
   if (env) {
     const char* const failure_reason = env->failure_reason();
     if (failure_reason != nullptr) {
-      result = (failure_reason == failure_reason_memlimit()) ? "oom" : "err";
+      result = (strcmp(failure_reason, failure_reason_memlimit()) == 0) ? "oom" : "err";
     }
   }
 


### PR DESCRIPTION
Trivial, but somewhat urgent fix to a jdk-22-only problem brought by an unclean backport of https://bugs.openjdk.org/browse/JDK-8325095.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331894](https://bugs.openjdk.org/browse/JDK-8331894) needs maintainer approval

### Issue
 * [JDK-8331894](https://bugs.openjdk.org/browse/JDK-8331894): [jdk22] compiler/print/CompileCommandMemLimit.java fails after backporting JDK-8325095 (**Bug** - P4 - Approved)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/190/head:pull/190` \
`$ git checkout pull/190`

Update a local copy of the PR: \
`$ git checkout pull/190` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 190`

View PR using the GUI difftool: \
`$ git pr show -t 190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/190.diff">https://git.openjdk.org/jdk22u/pull/190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/190#issuecomment-2100825291)