### PR TITLE
8331344: No compiler replay file with CompilerCommand MemLimit

### DIFF
--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -54,7 +54,7 @@
 ArenaStatCounter::ArenaStatCounter() :
   _current(0), _start(0), _peak(0),
   _na(0), _ra(0),
-  _limit(0), _hit_limit(false),
+  _limit(0), _hit_limit(false), _limit_in_process(false),
   _na_at_peak(0), _ra_at_peak(0), _live_nodes_at_peak(0)
 {}
 
@@ -464,17 +464,22 @@ void CompilationMemoryStatistic::on_arena_change(ssize_t diff, const Arena* aren
   CompilerThread* const th = Thread::current()->as_Compiler_thread();
 
   ArenaStatCounter* const arena_stat = th->arena_stat();
+  if (arena_stat->limit_in_process()) {
+    return; // avoid recursion on limit hit
+  }
+
   bool hit_limit_before = arena_stat->hit_limit();
 
   if (arena_stat->account(diff, (int)arena->get_tag())) { // new peak?
 
     // Limit handling
     if (arena_stat->hit_limit()) {
-
       char name[1024] = "";
       bool print = false;
       bool crash = false;
       CompilerType ct = compiler_none;
+
+      arena_stat->set_limit_in_process(true); // prevent recursive limit hits
 
       // get some more info
       const CompileTask* task = th->task();
@@ -514,6 +519,8 @@ void CompilationMemoryStatistic::on_arena_change(ssize_t diff, const Arena* aren
       } else {
         inform_compilation_about_oom(ct);
       }
+
+      arena_stat->set_limit_in_process(false);
     }
   }
 }

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.hpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.hpp
@@ -50,6 +50,7 @@ class ArenaStatCounter : public CHeapObj<mtCompiler> {
   // MemLimit handling
   size_t _limit;
   bool _hit_limit;
+  bool _limit_in_process;
 
   // Peak composition:
   // Size of node arena when total peaked (c2 only)
@@ -86,6 +87,9 @@ public:
 
   size_t limit() const              { return _limit; }
   bool   hit_limit() const          { return _hit_limit; }
+  bool   limit_in_process() const     { return _limit_in_process; }
+  void   set_limit_in_process(bool v) { _limit_in_process = v; }
+
 };
 
 class CompilationMemoryStatistic : public AllStatic {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [389f6fe9](https://github.com/openjdk/jdk/commit/389f6fe97c348e28d8573fe4754138d2a0bd6c0d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 2 May 2024 and was reviewed by Vladimir Kozlov and Ashutosh Mehra.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8331344](https://bugs.openjdk.org/browse/JDK-8331344) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331344](https://bugs.openjdk.org/browse/JDK-8331344): No compiler replay file with CompilerCommand MemLimit (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/191.diff">https://git.openjdk.org/jdk22u/pull/191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/191#issuecomment-2104687668)