### PR TITLE
8330027: Identity hashes of archived objects must be based on a reproducible random seed

### DIFF
--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -474,10 +474,8 @@ void ArchiveHeapWriter::update_header_for_requested_obj(oop requested_obj, oop s
   fake_oop->set_narrow_klass(nk);
 
   // We need to retain the identity_hash, because it may have been used by some hashtables
-  // in the shared heap. This also has the side effect of pre-initializing the
-  // identity_hash for all shared objects, so they are less likely to be written
-  // into during run time, increasing the potential of memory sharing.
-  if (src_obj != nullptr) {
+  // in the shared heap.
+  if (src_obj != nullptr && !src_obj->fast_no_hash_check()) {
     intptr_t src_hash = src_obj->identity_hash();
     fake_oop->set_mark(markWord::prototype().copy_set_hash(src_hash));
     assert(fake_oop->mark().is_unlocked(), "sanity");

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -279,11 +279,6 @@ bool HeapShared::archive_object(oop obj) {
     count_allocation(obj->size());
     ArchiveHeapWriter::add_source_obj(obj);
 
-    // The archived objects are discovered in a predictable order. Compute
-    // their identity_hash() as soon as we see them. This ensures that the
-    // the identity_hash in the object header will have a predictable value,
-    // making the archive reproducible.
-    obj->identity_hash();
     CachedOopInfo info = make_cached_oop_info();
     archived_object_cache()->put(obj, info);
     mark_native_pointers(obj);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "precompiled.hpp"
+#include "cds/cdsConfig.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/javaThreadStatus.hpp"
 #include "gc/shared/barrierSet.hpp"
@@ -103,7 +104,10 @@ Thread::Thread() {
   _vm_error_callbacks = nullptr;
 
   // thread-specific hashCode stream generator state - Marsaglia shift-xor form
-  _hashStateX = os::random();
+  // If we are dumping, keep ihashes constant. Note that during dumping we only
+  // ever run one java thread, and no other thread should generate ihashes either,
+  // so using a constant seed should work fine.
+  _hashStateX = CDSConfig::is_dumping_static_archive() ? 0x12345678 : os::random();
   _hashStateY = 842502087;
   _hashStateZ = 0x8767;    // (int)(3579807591LL & 0xffff) ;
   _hashStateW = 273326509;


### PR DESCRIPTION
This fixes an issue with CDS archive reproducibility that can happen under rare circumstances. See original JBS issue for details.

I had to manually resolve the hunk in src/hotspot/share/cds/heapShared.cpp because both
- 8251330: Reorder CDS archived heap to speed up relocation
- 8329431: Improve speed of writing CDS heap objects
were missing. 

Resolve was trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330027](https://bugs.openjdk.org/browse/JDK-8330027) needs maintainer approval

### Issue
 * [JDK-8330027](https://bugs.openjdk.org/browse/JDK-8330027): Identity hashes of archived objects must be based on a reproducible random seed (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/194.diff">https://git.openjdk.org/jdk22u/pull/194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/194#issuecomment-2104764147)