### PR TITLE
8331352: error: template-id not allowed for constructor/destructor in C++20

### DIFF
--- a/src/hotspot/share/gc/z/zArray.inline.hpp
+++ b/src/hotspot/share/gc/z/zArray.inline.hpp
@@ -96,7 +96,7 @@ ZActivatedArray<T>::ZActivatedArray(bool locked)
     _array() {}
 
 template <typename T>
-ZActivatedArray<T>::~ZActivatedArray<T>() {
+ZActivatedArray<T>::~ZActivatedArray() {
   FreeHeap(_lock);
 }
 

--- a/src/hotspot/share/utilities/chunkedList.hpp
+++ b/src/hotspot/share/utilities/chunkedList.hpp
@@ -44,7 +44,7 @@ template <class T, MEMFLAGS F> class ChunkedList : public CHeapObj<F> {
   }
 
  public:
-  ChunkedList<T, F>() : _top(_values), _next_used(nullptr), _next_free(nullptr) {}
+  ChunkedList() : _top(_values), _next_used(nullptr), _next_free(nullptr) {}
 
   bool is_full() const {
     return _top == end();

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -99,7 +99,7 @@ template <class T> class EventLogBase : public EventLog {
   EventRecord<T>* _records;
 
  public:
-  EventLogBase<T>(const char* name, const char* handle, int length = LogEventsBufferEntries):
+  EventLogBase(const char* name, const char* handle, int length = LogEventsBufferEntries):
     _mutex(Mutex::event, name),
     _name(name),
     _handle(handle),

--- a/src/hotspot/share/utilities/linkedlist.hpp
+++ b/src/hotspot/share/utilities/linkedlist.hpp
@@ -82,7 +82,7 @@ template <class E> class LinkedListNode : public AnyObj {
 template <class E> class LinkedList : public AnyObj {
  protected:
   LinkedListNode<E>*    _head;
-  NONCOPYABLE(LinkedList<E>);
+  NONCOPYABLE(LinkedList);
 
  public:
   LinkedList() : _head(nullptr) { }


### PR DESCRIPTION
It is needed to build OpenJDK-22 on Fedora 40 x86_64 (gcc-14.1.1-1.fc40.x86_64).
It needs all of [JDK-8328997](https://bugs.openjdk.org/browse/JDK-8328997) ([backport](https://github.com/openjdk/jdk22u/pull/197)), [JDK-8331352](https://bugs.openjdk.org/browse/JDK-8331352) (this [backport](https://github.com/openjdk/jdk22u/pull/198)) and [JDK-8324243](https://bugs.openjdk.org/browse/JDK-8324243) ([backport](https://github.com/openjdk/jdk22u/pull/199)).
Git cherry-pick was clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331352](https://bugs.openjdk.org/browse/JDK-8331352) needs maintainer approval

### Issue
 * [JDK-8331352](https://bugs.openjdk.org/browse/JDK-8331352): error: template-id not allowed for constructor/destructor in C++20 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/198/head:pull/198` \
`$ git checkout pull/198`

Update a local copy of the PR: \
`$ git checkout pull/198` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 198`

View PR using the GUI difftool: \
`$ git pr show -t 198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/198.diff">https://git.openjdk.org/jdk22u/pull/198.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/198#issuecomment-2106261632)