### PR TITLE
8324243: Compilation failures in java.desktop module with gcc 14

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -506,8 +506,10 @@ else
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
    # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
+   # calloc-transposed-args required for GCC 14 builds. (fixed upstream in Harfbuzz 032c931e1c0cfb20f18e5acb8ba005775242bd92)
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type \
-       expansion-to-defined dangling-reference maybe-uninitialized
+       expansion-to-defined dangling-reference maybe-uninitialized \
+       calloc-transposed-args
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis
    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
 

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiIn.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiIn.c
@@ -218,7 +218,7 @@ MidiMessage* MIDI_IN_GetMessage(MidiDeviceHandle* handle) {
             return NULL;
         }
     }
-    jdk_message = (MidiMessage*) calloc(sizeof(MidiMessage), 1);
+    jdk_message = (MidiMessage*) calloc(1, sizeof(MidiMessage));
     if (!jdk_message) {
         ERROR0("< ERROR: MIDI_IN_GetMessage(): out of memory\n");
         return NULL;

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
@@ -383,7 +383,7 @@ INT32 openMidiDevice(snd_rawmidi_stream_t direction, INT32 deviceIndex,
 
     TRACE0("> openMidiDevice()\n");
 
-    (*handle) = (MidiDeviceHandle*) calloc(sizeof(MidiDeviceHandle), 1);
+    (*handle) = (MidiDeviceHandle*) calloc(1, sizeof(MidiDeviceHandle));
     if (!(*handle)) {
         ERROR0("ERROR: openDevice: out of memory\n");
         return MIDI_OUT_OF_MEMORY;

--- a/src/java.desktop/share/native/libfontmanager/sunFont.c
+++ b/src/java.desktop/share/native/libfontmanager/sunFont.c
@@ -67,7 +67,7 @@ int isNullScalerContext(void *context) {
  */
 JNIEXPORT jlong JNICALL Java_sun_font_NullFontScaler_getGlyphImage
   (JNIEnv *env, jobject scaler, jlong pContext, jint glyphCode) {
-    void *nullscaler = calloc(sizeof(GlyphInfo), 1);
+    void *nullscaler = calloc(1, sizeof(GlyphInfo));
     return ptr_to_jlong(nullscaler);
 }
 


### PR DESCRIPTION
It is needed to build OpenJDK-22 on Fedora 40 x86_64 (gcc-14.1.1-1.fc40.x86_64).
It needs all of [JDK-8328997](https://bugs.openjdk.org/browse/JDK-8328997) ([backport](https://github.com/openjdk/jdk22u/pull/197)), [JDK-8331352](https://bugs.openjdk.org/browse/JDK-8331352) ([backport](https://github.com/openjdk/jdk22u/pull/198)) and [JDK-8324243](https://bugs.openjdk.org/browse/JDK-8324243) (this [backport](https://github.com/openjdk/jdk22u/pull/199)).
Git cherry-pick was clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324243](https://bugs.openjdk.org/browse/JDK-8324243) needs maintainer approval

### Issue
 * [JDK-8324243](https://bugs.openjdk.org/browse/JDK-8324243): Compilation failures in java.desktop module with gcc 14 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/199.diff">https://git.openjdk.org/jdk22u/pull/199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/199#issuecomment-2106262730)