### PR TITLE
8322078: ZipSourceCache.testKeySourceMapping() test fails with The process cannot access the file because it is being used by another process

### DIFF
--- a/test/jdk/java/util/zip/ZipFile/ZipSourceCache.java
+++ b/test/jdk/java/util/zip/ZipFile/ZipSourceCache.java
@@ -25,6 +25,7 @@
  * @bug 8317678
  * @modules java.base/java.util.zip:open
  * @summary Fix up hashCode() for ZipFile.Source.Key
+ * @library /test/lib
  * @run junit/othervm ZipSourceCache
  */
 
@@ -34,6 +35,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.zip.*;
+import jdk.test.lib.util.FileUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
@@ -62,7 +64,7 @@ public class ZipSourceCache {
 
     @AfterAll
     public static void cleanup() throws IOException {
-        Files.deleteIfExists(Path.of(ZIPFILE_NAME));
+        FileUtils.deleteFileIfExistsWithRetry(Path.of(ZIPFILE_NAME));
     }
 
     /*


### PR DESCRIPTION
Hi all,

This is clean backport of [JDK-8322078](https://bugs.openjdk.org/browse/JDK-8322078). The change has been  verified on windows-x64. The risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322078](https://bugs.openjdk.org/browse/JDK-8322078) needs maintainer approval

### Issue
 * [JDK-8322078](https://bugs.openjdk.org/browse/JDK-8322078): ZipSourceCache.testKeySourceMapping() test fails with The process cannot access the file because it is being used by another process (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/201/head:pull/201` \
`$ git checkout pull/201`

Update a local copy of the PR: \
`$ git checkout pull/201` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 201`

View PR using the GUI difftool: \
`$ git pr show -t 201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/201.diff">https://git.openjdk.org/jdk22u/pull/201.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/201#issuecomment-2109132561)