### PR TITLE
8261433: Better pkcs11 performance for libpkcs11:C_EncryptInit/libpkcs11:C_DecryptInit

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -799,6 +799,24 @@ public class PKCS11 {
     public native void C_EncryptInit(long hSession, CK_MECHANISM pMechanism,
             long hKey) throws PKCS11Exception;
 
+    /**
+     * C_GCMEncryptInitWithRetry initializes a GCM encryption operation and retry
+     * with alternative param structure for max compatibility.
+     * (Encryption and decryption)
+     *
+     * @param hSession the session's handle
+     *         (PKCS#11 param: CK_SESSION_HANDLE hSession)
+     * @param pMechanism the encryption mechanism
+     *         (PKCS#11 param: CK_MECHANISM_PTR pMechanism)
+     * @param hKey the handle of the encryption key
+     *         (PKCS#11 param: CK_OBJECT_HANDLE hKey)
+     * @param useNormativeVerFirst whether to use normative version of GCM parameter first
+     * @exception PKCS11Exception If function returns other value than CKR_OK.
+     * @preconditions
+     * @postconditions
+     */
+    public native void C_GCMEncryptInitWithRetry(long hSession, CK_MECHANISM pMechanism,
+            long hKey, boolean useNormativeVerFirst) throws PKCS11Exception;
 
     /**
      * C_Encrypt encrypts single-part data.
@@ -893,6 +911,24 @@ public class PKCS11 {
     public native void C_DecryptInit(long hSession, CK_MECHANISM pMechanism,
             long hKey) throws PKCS11Exception;
 
+    /**
+     * C_GCMDecryptInitWithRetry initializes a GCM decryption operation
+     * with alternative param structure for max compatibility.
+     * (Encryption and decryption)
+     *
+     * @param hSession the session's handle
+     *         (PKCS#11 param: CK_SESSION_HANDLE hSession)
+     * @param pMechanism the decryption mechanism
+     *         (PKCS#11 param: CK_MECHANISM_PTR pMechanism)
+     * @param hKey the handle of the decryption key
+     *         (PKCS#11 param: CK_OBJECT_HANDLE hKey)
+     * @param useNormativeVerFirst whether to use normative version of GCM parameter first
+     * @exception PKCS11Exception If function returns other value than CKR_OK.
+     * @preconditions
+     * @postconditions
+     */
+    public native void C_GCMDecryptInitWithRetry(long hSession, CK_MECHANISM pMechanism,
+            long hKey, boolean useNormativeVerFirst) throws PKCS11Exception;
 
     /**
      * C_Decrypt decrypts encrypted data in a single part.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_crypt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_crypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -72,7 +72,6 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1EncryptInit
 {
     CK_SESSION_HANDLE ckSessionHandle;
     CK_MECHANISM_PTR ckpMechanism = NULL;
-    CK_MECHANISM_PTR ckpTemp;
     CK_OBJECT_HANDLE ckKeyHandle;
     CK_RV rv;
 
@@ -90,20 +89,60 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1EncryptInit
     rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle, ckpMechanism,
                                         ckKeyHandle);
 
-    if (ckpMechanism->mechanism == CKM_AES_GCM) {
-        if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
-            // retry with CKM_GCM_PARAMS structure in pkcs11t.h
-            TRACE0("DEBUG C_EncryptInit: retry with CK_GCM_PARAMS\n");
-            ckpTemp = updateGCMParams(env, ckpMechanism);
-            if (ckpTemp != NULL) { // only re-call if conversion succeeds
-                ckpMechanism = ckpTemp;
-                rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle, ckpMechanism,
-                        ckKeyHandle);
-            }
+    TRACE1("DEBUG C_EncryptInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
+
+    TRACE0("FINISHED\n");
+}
+
+/*
+ * Class:     sun_security_pkcs11_wrapper_PKCS11
+ * Method:    C_GCMEncryptInitWithRetry
+ * Signature: (JLsun/security/pkcs11/wrapper/CK_MECHANISM;JZ)V
+ * Parametermapping:                    *PKCS11*
+ * @param   jlong jSessionHandle        CK_SESSION_HANDLE hSession
+ * @param   jobject jMechanism          CK_MECHANISM_PTR pMechanism
+ * @param   jlong jKeyHandle            CK_OBJECT_HANDLE hKey
+ * @param   jboolean useNormVerFirst    CK_BBOOL retry (only retry if the first
+ *                                      init uses the non-normative version)
+ */
+JNIEXPORT void JNICALL
+Java_sun_security_pkcs11_wrapper_PKCS11_C_1GCMEncryptInitWithRetry
+(JNIEnv *env, jobject obj, jlong jSessionHandle,
+ jobject jMechanism, jlong jKeyHandle, jboolean useNormVerFirst)
+{
+    CK_SESSION_HANDLE ckSessionHandle;
+    CK_MECHANISM_PTR ckpMechanism = NULL;
+    CK_OBJECT_HANDLE ckKeyHandle;
+    CK_BBOOL retry = FALSE;
+    CK_RV rv = 1;
+
+    CK_FUNCTION_LIST_PTR ckpFunctions = getFunctionList(env, obj);
+    if (ckpFunctions == NULL) { return; }
+
+    ckSessionHandle = jLongToCKULong(jSessionHandle);
+    ckKeyHandle = jLongToCKULong(jKeyHandle);
+    ckpMechanism = jMechanismToCKMechanismPtr(env, jMechanism);
+
+    if ((*env)->ExceptionCheck(env)) { return; }
+
+    // if !useNormVerFirst, then update 'ckpMechanism' in place w/
+    // non-normative GCM params.
+    retry = (!useNormVerFirst && updateGCMParams(env, ckpMechanism) != NULL);
+
+    rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle, ckpMechanism, ckKeyHandle);
+
+    if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
+        // retry and update 'ckpMechanism' in place w/ normative GCM params.
+        if (retry && updateGCMParams(env, ckpMechanism) != NULL) {
+            TRACE0("DEBUG retry C_EncryptInit\n");
+            rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle,
+                ckpMechanism, ckKeyHandle);
         }
     }
 
-    TRACE1("DEBUG C_EncryptInit: freed pMech = %p\n", ckpMechanism);
+    TRACE1("DEBUG C_GCMEncryptInitWithRetry: freed pMech = %p\n", ckpMechanism);
     freeCKMechanismPtr(ckpMechanism);
     if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
 
@@ -312,7 +351,6 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1DecryptInit
 {
     CK_SESSION_HANDLE ckSessionHandle;
     CK_MECHANISM_PTR ckpMechanism = NULL;
-    CK_MECHANISM_PTR ckpTemp;
     CK_OBJECT_HANDLE ckKeyHandle;
     CK_RV rv;
 
@@ -330,20 +368,61 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1DecryptInit
     rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
                                         ckKeyHandle);
 
-    if (ckpMechanism->mechanism == CKM_AES_GCM) {
-        if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
-            // retry with CKM_GCM_PARAMS structure in pkcs11t.h
-            TRACE0("DEBUG C_DecryptInit: retry with CK_GCM_PARAMS\n");
-            ckpTemp = updateGCMParams(env, ckpMechanism);
-            if (ckpTemp != NULL) { // only re-call if conversion succeeds
-                ckpMechanism = ckpTemp;
-                rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
-                        ckKeyHandle);
-            }
+    TRACE1("DEBUG C_DecryptInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
+
+    TRACE0("FINISHED\n");
+}
+
+/*
+ * Class:     sun_security_pkcs11_wrapper_PKCS11
+ * Method:    C_GCMDecryptInitWithRetry
+ * Signature: (JLsun/security/pkcs11/wrapper/CK_MECHANISM;JZ)V
+ * Parametermapping:                    *PKCS11*
+ * @param   jlong jSessionHandle        CK_SESSION_HANDLE hSession
+ * @param   jobject jMechanism          CK_MECHANISM_PTR pMechanism
+ * @param   jlong jKeyHandle            CK_OBJECT_HANDLE hKey
+ * @param   jboolean useNormVerFirst    CK_BBOOL retry (only retry if the first
+ *                                      init uses the non-normative version)
+ */
+JNIEXPORT void JNICALL
+Java_sun_security_pkcs11_wrapper_PKCS11_C_1GCMDecryptInitWithRetry
+(JNIEnv *env, jobject obj, jlong jSessionHandle,
+ jobject jMechanism, jlong jKeyHandle, jboolean useNormVerFirst)
+{
+    CK_SESSION_HANDLE ckSessionHandle;
+    CK_MECHANISM_PTR ckpMechanism = NULL;
+    CK_OBJECT_HANDLE ckKeyHandle;
+    CK_BBOOL retry = FALSE;
+    CK_RV rv = 1;
+
+    CK_FUNCTION_LIST_PTR ckpFunctions = getFunctionList(env, obj);
+    if (ckpFunctions == NULL) { return; }
+
+    ckSessionHandle = jLongToCKULong(jSessionHandle);
+    ckKeyHandle = jLongToCKULong(jKeyHandle);
+    ckpMechanism = jMechanismToCKMechanismPtr(env, jMechanism);
+
+    if ((*env)->ExceptionCheck(env)) { return; }
+
+    // if !useNormVerFirst, then update 'ckpMechanism' in place w/
+    // non-normative GCM params.
+    retry = (!useNormVerFirst && updateGCMParams(env, ckpMechanism) != NULL);
+
+    rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
+        ckKeyHandle);
+
+    if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
+        // retry and update 'ckpMechanism' in place w/ normative GCM params.
+        if (retry && updateGCMParams(env, ckpMechanism) != NULL) {
+            TRACE0("DEBUG retry C_DecryptInit with normative CK_GCM_PARAMS\n");
+            rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
+                ckKeyHandle);
         }
     }
 
-    TRACE1("DEBUG C_DecryptInit: freed pMech = %p\n", ckpMechanism);
+    TRACE1("DEBUG C_GCMDecryptInitWithRetry: freed pMech = %p\n", ckpMechanism);
     freeCKMechanismPtr(ckpMechanism);
     if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
 


### PR DESCRIPTION
This is a clean backport of JDK-8261433, Internal test are green

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8261433](https://bugs.openjdk.org/browse/JDK-8261433) needs maintainer approval

### Issue
 * [JDK-8261433](https://bugs.openjdk.org/browse/JDK-8261433): Better pkcs11 performance for libpkcs11:C_EncryptInit/libpkcs11:C_DecryptInit (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/203.diff">https://git.openjdk.org/jdk22u/pull/203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/203#issuecomment-2109904930)