### PR TITLE
8329958: Windows x86 build fails: downcallLinker.cpp(36) redefinition

### DIFF
--- a/src/hotspot/share/prims/downcallLinker.hpp
+++ b/src/hotspot/share/prims/downcallLinker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,8 @@ public:
                                          int captured_state_mask,
                                          bool needs_transition);
 
-  static void capture_state(int32_t* value_ptr, int captured_state_mask);
+  // This is defined as JVM_LEAF which adds the JNICALL modifier.
+  static void JNICALL capture_state(int32_t* value_ptr, int captured_state_mask);
 
   class StubGenerator : public StubCodeGenerator {
     BasicType* _signature;


### PR DESCRIPTION
Trivial backport to fix Windows 32-bit build issue.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329958](https://bugs.openjdk.org/browse/JDK-8329958) needs maintainer approval

### Issue
 * [JDK-8329958](https://bugs.openjdk.org/browse/JDK-8329958): Windows x86 build fails: downcallLinker.cpp(36) redefinition (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/224.diff">https://git.openjdk.org/jdk22u/pull/224.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/224#issuecomment-2134089847)