### PR TITLE
8325763: Revert properties: vm.opt.x.*

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ package gc.arguments;
  * @bug 8006088
  * @summary Tests argument processing for initial and maximum heap size for the G1 collector
  * @key flag-sensitive
- * @requires vm.gc.G1 & vm.opt.x.Xmx == null & vm.opt.x.Xms == null & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.gc.G1 & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package gc.arguments;
  * @test TestHeapFreeRatio
  * @bug 8025661
  * @summary Test parsing of -Xminf and -Xmaxf
- * @requires vm.opt.x.Xminf == null & vm.opt.x.Xmaxf == null & vm.opt.MinHeapFreeRatio == null & vm.opt.MaxHeapFreeRatio == null
+ * @requires vm.opt.MinHeapFreeRatio == null & vm.opt.MaxHeapFreeRatio == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ package gc.arguments;
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
  * @key flag-sensitive
- * @requires vm.gc.Serial & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null & vm.opt.x.Xms == null & vm.opt.x.Xmx == null
+ * @requires vm.gc.Serial & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -44,7 +44,7 @@ package gc.arguments;
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
  * @key flag-sensitive
- * @requires vm.gc.Parallel & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null & vm.opt.x.Xms == null & vm.opt.x.Xmx == null
+ * @requires vm.gc.Parallel & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -59,7 +59,7 @@ package gc.arguments;
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
  * @key flag-sensitive
- * @requires vm.gc.G1 & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null & vm.opt.x.Xms == null & vm.opt.x.Xmx == null
+ * @requires vm.gc.G1 & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ package gc.arguments;
  * @summary Tests argument processing for initial and maximum heap size for the
  * parallel collectors.
  * @key flag-sensitive
- * @requires vm.gc.Parallel & vm.opt.x.Xmx == null & vm.opt.x.Xms == null & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.gc.Parallel & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ package gc.arguments;
  * @bug 8006088
  * @summary Tests argument processing for initial and maximum heap size for the Serial collector
  * @key flag-sensitive
- * @requires vm.gc.Serial & vm.opt.x.Xmx == null & vm.opt.x.Xms == null & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.gc.Serial & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jdk.internal.foreign.CABI;
@@ -83,10 +82,6 @@ public class VMProps implements Callable<Map<String, String>> {
                 value = ERROR_STATE + t;
             }
             map.put(key, value);
-        }
-
-        public void putAll(Map<String, String> map) {
-            map.entrySet().forEach(e -> put(e.getKey(), () -> e.getValue()));
         }
     }
 
@@ -140,7 +135,6 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("jdk.containerized", this::jdkContainerized);
         map.put("vm.flagless", this::isFlagless);
         map.put("jdk.foreign.linker", this::jdkForeignLinker);
-        map.putAll(xOptFlags()); // -Xmx4g -> @requires vm.opt.x.Xmx == "4g" )
         vmGC(map); // vm.gc.X = true/false
         vmGCforCDS(map); // may set vm.gc
         vmOptFinalFlags(map);
@@ -717,27 +711,6 @@ public class VMProps implements Callable<Map<String, String>> {
 
     private Stream<String> allFlags() {
         return Stream.of((System.getProperty("test.vm.opts", "") + " " + System.getProperty("test.java.opts", "")).trim().split("\\s+"));
-    }
-
-    /**
-     * Parses extra options, options that start with -X excluding the
-     * bare -X option (as it is not considered an extra option).
-     * Ignores extra options not starting with -X
-     *
-     * This could be improved to handle extra options not starting
-     * with -X as well as "standard" options.
-     */
-    private Map<String, String> xOptFlags() {
-        return allFlags()
-            .filter(s -> s.startsWith("-X") && !s.startsWith("-XX:") && !s.equals("-X"))
-            .map(s -> s.replaceFirst("-", ""))
-            .map(flag -> flag.splitWithDelimiters("[:0123456789]", 2))
-            .collect(Collectors.toMap(a -> "vm.opt.x." + a[0],
-                                      a -> (a.length == 1)
-                                      ? "true" // -Xnoclassgc
-                                      : (a[1].equals(":")
-                                         ? a[2]            // ["-XshowSettings", ":", "system"]
-                                         : a[1] + a[2]))); // ["-Xmx", "4", "g"]
     }
 
     /*


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0aaec975](https://github.com/openjdk/jdk/commit/0aaec97527ddf2b229a9dd6beaa7ff55c635dee5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Leo Korinth on 16 Feb 2024 and was reviewed by Albert Mingkun Yang and Stefan Karlsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325763](https://bugs.openjdk.org/browse/JDK-8325763) needs maintainer approval

### Issue
 * [JDK-8325763](https://bugs.openjdk.org/browse/JDK-8325763): Revert properties: vm.opt.x.* (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/229.diff">https://git.openjdk.org/jdk22u/pull/229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/229#issuecomment-2138690543)