### PR TITLE
8331771: ZGC: Remove OopMapCacheAlloc_lock ordering workaround

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -95,7 +95,6 @@ class CollectedHeap : public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class JVMCIVMStructs;
   friend class IsGCActiveMark; // Block structured external access to _is_gc_active
-  friend class DisableIsGCActiveMark; // Disable current IsGCActiveMark
   friend class MemAllocator;
   friend class ParallelObjectIterator;
 

--- a/src/hotspot/share/gc/shared/isGCActiveMark.cpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.cpp
@@ -42,15 +42,3 @@ IsGCActiveMark::~IsGCActiveMark() {
   assert(heap->is_gc_active(), "Sanity");
   heap->_is_gc_active = false;
 }
-
-DisableIsGCActiveMark::DisableIsGCActiveMark() {
-  CollectedHeap* heap = Universe::heap();
-  assert(heap->is_gc_active(), "Not reentrant");
-  heap->_is_gc_active = false;
-}
-
-DisableIsGCActiveMark::~DisableIsGCActiveMark() {
-  CollectedHeap* heap = Universe::heap();
-  assert(!heap->is_gc_active(), "Sanity");
-  heap->_is_gc_active = true;
-}

--- a/src/hotspot/share/gc/shared/isGCActiveMark.hpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.hpp
@@ -36,10 +36,4 @@ class IsGCActiveMark : public StackObj {
   ~IsGCActiveMark();
 };
 
-class DisableIsGCActiveMark : public StackObj {
- public:
-  DisableIsGCActiveMark();
-  ~DisableIsGCActiveMark();
-};
-
 #endif // SHARE_GC_SHARED_ISGCACTIVEMARK_HPP

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -493,9 +493,6 @@ void ZVerify::after_mark() {
     roots_strong(true /* verify_after_old_mark */);
   }
   if (ZVerifyObjects) {
-    // Workaround OopMapCacheAlloc_lock reordering with the StackWatermark_lock
-    DisableIsGCActiveMark mark;
-
     objects(false /* verify_weaks */);
     guarantee(zverify_broken_object == zaddress::null, "Verification failed");
   }


### PR DESCRIPTION
I'd like to backport the change of https://bugs.openjdk.org/browse/JDK-8331771 to JDK22

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8331771](https://bugs.openjdk.org/browse/JDK-8331771) needs maintainer approval

### Issue
 * [JDK-8331771](https://bugs.openjdk.org/browse/JDK-8331771): ZGC: Remove OopMapCacheAlloc_lock ordering workaround (**Enhancement** - P4 - Requested)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/232.diff">https://git.openjdk.org/jdk22u/pull/232.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/232#issuecomment-2141297900)