### PR TITLE
8325616: JFR ZGC Allocation Stall events should record stack traces

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1131,7 +1131,7 @@
     <Field type="uint" name="gcId" label="GC Identifier" relation="GcId" />
   </Event>
 
-  <Event name="ZAllocationStall" category="Java Virtual Machine, GC, Detailed" label="ZGC Allocation Stall" description="Time spent waiting for memory to become available" thread="true">
+  <Event name="ZAllocationStall" category="Java Virtual Machine, GC, Detailed" label="ZGC Allocation Stall" description="Time spent waiting for memory to become available" thread="true" stackTrace="true">
     <Field type="ZPageTypeType" name="type" label="Type" />
     <Field type="ulong" contentType="bytes" name="size" label="Size" />
   </Event>

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -824,6 +824,7 @@
 
     <event name="jdk.ZAllocationStall">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -824,6 +824,7 @@
 
     <event name="jdk.ZAllocationStall">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 


### PR DESCRIPTION
Backport JDK-8325616 to record stack traces during  jdk.ZAllocationStall event.

**Verification**

1. Ran jdk_jfr and hotspot_gc tests with ZGC. All tests passed.
2. Output of print jfr on a sample java program that resulted in allocation stall.

```
jdk.ZAllocationStall {
  startTime = 10:53:37.434
  duration = 615 ms
  type = "Small"
  size = 2.0 MB
  eventThread = "Thread-107" (javaThreadId = 145)
  stackTrace = [
    StressZGC.work(int, Set) line: 30
    StressZGC.work(int, Set) line: 26
    StressZGC.work(int, Set) line: 26
    StressZGC.work(int, Set) line: 26
    StressZGC.work(int, Set) line: 26
    ...
  ]
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8325616](https://bugs.openjdk.org/browse/JDK-8325616) needs maintainer approval

### Issue
 * [JDK-8325616](https://bugs.openjdk.org/browse/JDK-8325616): JFR ZGC Allocation Stall events should record stack traces (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/238.diff">https://git.openjdk.org/jdk22u/pull/238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/238#issuecomment-2145098585)