### PR TITLE
8331931: JFR: Avoid loading regex classes during startup

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,10 +287,11 @@ public final class SecuritySupport {
 
     public static List<SafePath> getPredefinedJFCFiles() {
         List<SafePath> list = new ArrayList<>();
-        try (var ds = doPrivilegedIOWithReturn(() -> Files.newDirectoryStream(JFC_DIRECTORY.toPath(), "*.jfc"))) {
+        try (var ds = doPrivilegedIOWithReturn(() -> Files.newDirectoryStream(JFC_DIRECTORY.toPath()))) {
             for (Path path : ds) {
                 SafePath s = new SafePath(path);
-                if (!SecuritySupport.isDirectory(s)) {
+                String text = s.toString();
+                if (text.endsWith(".jfc") && !SecuritySupport.isDirectory(s)) {
                     list.add(s);
                 }
             }


### PR DESCRIPTION
Backport [JDK-8331931](https://bugs.openjdk.org/browse/JDK-8331931) JFR: Avoid loading regex classes during startup


### Validation
Run test ```make test TEST=jdk/jdk/jfr```, all tests passed.

```
Test results: passed: 592
Report written to /local/home/xlpeng/repos/jdk22u-xlpeng/build/linux-aarch64-server-fastdebug/test-results/jtreg_test_jdk_jdk_jfr/html/report.html
Results written to /local/home/xlpeng/repos/jdk22u-xlpeng/build/linux-aarch64-server-fastdebug/test-support/jtreg_test_jdk_jdk_jfr
Finished running test 'jtreg:test/jdk/jdk/jfr'
Test report is stored in build/linux-aarch64-server-fastdebug/test-results/jtreg_test_jdk_jdk_jfr

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/jdk/jfr                              592   592     0     0   
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-aarch64-server-fastdebug'

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8331931](https://bugs.openjdk.org/browse/JDK-8331931) needs maintainer approval

### Issue
 * [JDK-8331931](https://bugs.openjdk.org/browse/JDK-8331931): JFR: Avoid loading regex classes during startup (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/241/head:pull/241` \
`$ git checkout pull/241`

Update a local copy of the PR: \
`$ git checkout pull/241` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 241`

View PR using the GUI difftool: \
`$ git pr show -t 241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/241.diff">https://git.openjdk.org/jdk22u/pull/241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/241#issuecomment-2148577540)