### PR TITLE
8332499: Gtest codestrings.validate_vm fail on linux x64 when hsdis is present

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -49,7 +49,8 @@ static const char* replace_addr_expr(const char* str)
     // Padding: riscv
     std::basic_string<char> tmp4  = std::regex_replace(tmp3, std::regex("\\s+<addr>:\\s+unimp"), "");
     // Padding: x64
-    std::basic_string<char> red  = std::regex_replace(tmp4, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
+    std::basic_string<char> tmp5  = std::regex_replace(tmp4, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
+    std::basic_string<char> red  = std::regex_replace(tmp5, std::regex("(\\s+<addr>:\\s+nop)[ \\t]*"), "$1");
 
     return os::strdup(red.c_str());
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7dbd0338](https://github.com/openjdk/jdk/commit/7dbd03388eef9cddbab6a622338b00ce250be3dc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 5 Jun 2024 and was reviewed by Tobias Hartmann and Christian Hagedorn.

The change has been verified, the risk is low.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8332499](https://bugs.openjdk.org/browse/JDK-8332499) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332499](https://bugs.openjdk.org/browse/JDK-8332499): Gtest codestrings.validate_vm fail on linux x64 when hsdis is present (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/242.diff">https://git.openjdk.org/jdk22u/pull/242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/242#issuecomment-2149087777)