### PR TITLE
8321204: C2: assert(false) failed: node should be in igvn hash table

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4917,16 +4917,7 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
         const Type* t_no_spec = t->remove_speculative();
         if (t_no_spec != t) {
           bool in_hash = igvn.hash_delete(n);
-#ifdef ASSERT
-          if (!in_hash) {
-            tty->print_cr("current graph:");
-            n->dump_bfs(MaxNodeLimit, nullptr, "S$");
-            tty->cr();
-            tty->print_cr("erroneous node:");
-            n->dump();
-            assert(false, "node should be in igvn hash table");
-          }
-#endif
+          assert(in_hash || n->hash() == Node::NO_HASH, "node should be in igvn hash table");
           tn->set_type(t_no_spec);
           igvn.hash_insert(n);
           igvn._worklist.push(n); // give it a chance to go away


### PR DESCRIPTION
Clean backport of [JDK-8321204](https://bugs.openjdk.org/browse/JDK-8321204).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8321204](https://bugs.openjdk.org/browse/JDK-8321204) needs maintainer approval

### Issue
 * [JDK-8321204](https://bugs.openjdk.org/browse/JDK-8321204): C2: assert(false) failed: node should be in igvn hash table (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/245/head:pull/245` \
`$ git checkout pull/245`

Update a local copy of the PR: \
`$ git checkout pull/245` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 245`

View PR using the GUI difftool: \
`$ git pr show -t 245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/245.diff">https://git.openjdk.org/jdk22u/pull/245.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/245#issuecomment-2151903311)