### PR TITLE
Backport d130d2f4f46d37a2b924343de19d012c129b0a55

### DIFF
--- a/src/jdk.hotspot.agent/test/libproc/Makefile
+++ b/src/jdk.hotspot.agent/test/libproc/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -19,7 +19,7 @@
 # Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 # or visit www.oracle.com if you need additional information or have any
 # questions.
-#  
+#
 #
 
 all:

--- a/src/utils/LogCompilation/Makefile
+++ b/src/utils/LogCompilation/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -19,7 +19,7 @@
 # Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 # or visit www.oracle.com if you need additional information or have any
 # questions.
-#  
+#
 #
 PKGLIST = \
 com.sun.hotspot.tools.compiler
@@ -49,7 +49,7 @@ SRC_DIR    = src
 BUILD_DIR  = build
 OUTPUT_DIR = $(BUILD_DIR)/classes
 
-# gnumake 3.78.1 does not accept the *s, 
+# gnumake 3.78.1 does not accept the *s,
 # so use the shell to expand them
 ALLFILES := $(patsubst %,$(SRC_DIR)/%,$(FILELIST))
 ALLFILES := $(shell /bin/ls $(ALLFILES))

--- a/test/jdk/java/rmi/reliability/benchmark/bench/Makefile
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2000, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -47,4 +47,3 @@ all: .classes
 
 clean:
 	rm -f *.class .classes
-

--- a/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Makefile
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -72,4 +72,3 @@ altroot.clean:
 
 clean: altroot.clean
 	rm -f *.class .classes
-

--- a/test/jdk/javax/crypto/SecretKeyFactory/evilprov/Makefile
+++ b/test/jdk/javax/crypto/SecretKeyFactory/evilprov/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 JAVABIN=$(JAVA_BASE)/bin
 JAVAC=$(JAVABIN)/javac
 JAVA=$(JAVABIN)/java
-JAR=$(JAVABIN)/jar 
+JAR=$(JAVABIN)/jar
 JARSIGNER=$(JAVABIN)/jarsigner
 
 # Compile-time flags and paths


### PR DESCRIPTION
Hi all,
  This is clean backport to delete several extra  trailing whitespaces and extra trailing lines in several Makefiles. It's trivial fix, no risk.
  The commit being backported was authored by SendaoYan on 7 Jun 2024 and was reviewed by Erik Joelsson, Christian Hagedorn, Chen Liang and Julian Waters.

Thanks.