### PR TITLE
8332935: Crash:  assert(*lastPtr != 0) failed: Mismatched JNINativeInterface tables, check for new entries

### DIFF
--- a/src/hotspot/share/prims/jniCheck.cpp
+++ b/src/hotspot/share/prims/jniCheck.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2295,7 +2295,7 @@ struct JNINativeInterface_* jni_functions_check() {
   // make sure the last pointer in the checked table is not null, indicating
   // an addition to the JNINativeInterface_ structure without initializing
   // it in the checked table.
-  debug_only(int *lastPtr = (int *)((char *)&checked_jni_NativeInterface + \
+  debug_only(intptr_t *lastPtr = (intptr_t *)((char *)&checked_jni_NativeInterface + \
              sizeof(*unchecked_jni_NativeInterface) - sizeof(char *));)
   assert(*lastPtr != 0,
          "Mismatched JNINativeInterface tables, check for new entries");


### PR DESCRIPTION
Clean backport of fixing JNINativeInterface tables checking assertion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8332935](https://bugs.openjdk.org/browse/JDK-8332935) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332935](https://bugs.openjdk.org/browse/JDK-8332935): Crash:  assert(*lastPtr != 0) failed: Mismatched JNINativeInterface tables, check for new entries (**Bug** - P2 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/247/head:pull/247` \
`$ git checkout pull/247`

Update a local copy of the PR: \
`$ git checkout pull/247` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 247`

View PR using the GUI difftool: \
`$ git pr show -t 247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/247.diff">https://git.openjdk.org/jdk22u/pull/247.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/247#issuecomment-2161950833)