### PR TITLE
8325754: Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -1127,13 +1127,18 @@ public abstract class AbstractQueuedLongSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -1506,13 +1506,18 @@ public abstract class AbstractQueuedSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }


### PR DESCRIPTION
**Notes**
Backport of [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754).

Unlink 'ConditionNode' before they are transferred to the sync queue as G1 seems to be able to collect “dead” ConditionNode instances during minor collections only if no formerly alive ConditionNode instances were promoted to the old generation and died there, which often cannot be avoided since e.g. on application startup many objects are promoted to the old generation after a few collections.

**Verification**

* jdk_util, Tier 1 & Tier 2 tests passed.
* Ran G1LoiteringConditionNodes.java (sample code from bug description) and verified that YG GC time is not increasing after full GC.

_Before PR_

```
dev-dsk-neethp-jdk-2c-ad54955c % /home/neethp/Development/jdk22u/build/linux-x86_64-server-release/images/jdk/bin/java -Xms2048m -Xmx2048m -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=20 '-Xlog:gc*,gc+age*=trace' -cp . G1LoiteringConditionNodes | grep -E 'Pause.*ms'
[0.965s][info ][gc          ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 103M->1M(2048M) 5.021ms
[2.578s][info ][gc          ] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 155M->1M(2048M) 2.136ms
[6.991s][info ][gc          ] GC(2) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.413ms
[11.329s][info ][gc          ] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.011ms
[15.696s][info ][gc          ] GC(4) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.480ms
[20.099s][info ][gc          ] GC(5) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.049ms
[24.522s][info ][gc          ] GC(6) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.911ms
[28.952s][info ][gc          ] GC(7) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.860ms
[33.381s][info ][gc          ] GC(8) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.503ms
[37.810s][info ][gc          ] GC(9) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.744ms
[42.243s][info ][gc          ] GC(10) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.975ms
[46.684s][info ][gc          ] GC(11) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.122ms
[51.127s][info ][gc          ] GC(12) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.998ms
[55.548s][info ][gc          ] GC(13) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.299ms
[59.986s][info ][gc          ] GC(14) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.598ms
[64.418s][info ][gc          ] GC(15) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.789ms
[68.848s][info ][gc          ] GC(16) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.097ms
[73.271s][info ][gc          ] GC(17) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.081ms
[77.692s][info ][gc          ] GC(18) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.006ms
[82.113s][info ][gc          ] GC(19) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.200ms
[86.551s][info ][gc          ] GC(20) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.198ms
[90.996s][info ][gc          ] GC(21) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.294ms
[95.435s][info ][gc          ] GC(22) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.004ms
[99.871s][info ][gc          ] GC(23) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.336ms
[104.303s][info ][gc          ] GC(24) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.160ms
[108.730s][info ][gc          ] GC(25) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.281ms
[113.155s][info ][gc          ] GC(26) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.225ms
[117.592s][info ][gc          ] GC(27) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.019ms
[120.104s][info ][gc             ] GC(28) Pause Full (System.gc()) 230M->1M(2048M) 36.340ms
[124.512s][info ][gc             ] GC(29) Pause Young (Normal) (G1 Evacuation Pause) 410M->1M(2048M) 4.144ms
[128.914s][info ][gc             ] GC(30) Pause Young (Normal) (G1 Evacuation Pause) 409M->2M(2048M) 4.628ms
[133.310s][info ][gc             ] GC(31) Pause Young (Normal) (G1 Evacuation Pause) 409M->2M(2048M) 4.521ms
[137.702s][info ][gc             ] GC(32) Pause Young (Normal) (G1 Evacuation Pause) 409M->3M(2048M) 5.135ms
[142.103s][info ][gc             ] GC(33) Pause Young (Normal) (G1 Evacuation Pause) 410M->3M(2048M) 4.669ms
[146.507s][info ][gc             ] GC(34) Pause Young (Normal) (G1 Evacuation Pause) 409M->3M(2048M) 5.043ms
[150.904s][info ][gc             ] GC(35) Pause Young (Normal) (G1 Evacuation Pause) 409M->4M(2048M) 5.489ms
[155.290s][info ][gc             ] GC(36) Pause Young (Normal) (G1 Evacuation Pause) 409M->4M(2048M) 5.246ms
[159.679s][info ][gc             ] GC(37) Pause Young (Normal) (G1 Evacuation Pause) 409M->5M(2048M) 5.922ms
[164.070s][info ][gc             ] GC(38) Pause Young (Normal) (G1 Evacuation Pause) 410M->5M(2048M) 6.073ms
[168.447s][info ][gc             ] GC(39) Pause Young (Normal) (G1 Evacuation Pause) 409M->6M(2048M) 5.724ms
[172.817s][info ][gc             ] GC(40) Pause Young (Normal) (G1 Evacuation Pause) 410M->6M(2048M) 6.366ms
[177.185s][info ][gc             ] GC(41) Pause Young (Normal) (G1 Evacuation Pause) 409M->6M(2048M) 6.147ms
[181.550s][info ][gc             ] GC(42) Pause Young (Normal) (G1 Evacuation Pause) 409M->7M(2048M) 7.172ms
[185.889s][info ][gc             ] GC(43) Pause Young (Normal) (G1 Evacuation Pause) 409M->8M(2048M) 6.288ms
[190.242s][info ][gc             ] GC(44) Pause Young (Normal) (G1 Evacuation Pause) 410M->8M(2048M) 7.327ms
[194.583s][info ][gc             ] GC(45) Pause Young (Normal) (G1 Evacuation Pause) 410M->8M(2048M) 7.143ms
[198.920s][info ][gc             ] GC(46) Pause Young (Normal) (G1 Evacuation Pause) 410M->9M(2048M) 6.899ms
```


_After this change_

```
dev-dsk-neethp-jdk-2c-ad54955c % /home/neethp/Development/jdk22u/build/linux-x86_64-server-release/images/jdk/bin/java -Xms2048m -Xmx2048m -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=20 '-Xlog:gc*,gc+age*=trace' -cp . G1LoiteringConditionNodes | grep -E 'Pause.*ms'
[0.951s][info ][gc          ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 103M->1M(2048M) 5.572ms
[2.572s][info ][gc          ] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 155M->1M(2048M) 2.317ms
[6.975s][info ][gc          ] GC(2) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.753ms
[11.312s][info ][gc          ] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.230ms
[15.691s][info ][gc          ] GC(4) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.104ms
[20.092s][info ][gc          ] GC(5) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.668ms
[24.517s][info ][gc          ] GC(6) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.479ms
[28.940s][info ][gc          ] GC(7) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.326ms
[33.360s][info ][gc          ] GC(8) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.528ms
[37.777s][info ][gc          ] GC(9) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.501ms
[42.205s][info ][gc          ] GC(10) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.843ms
[46.637s][info ][gc          ] GC(11) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.988ms
[51.075s][info ][gc          ] GC(12) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.292ms
[55.500s][info ][gc          ] GC(13) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.189ms
[59.953s][info ][gc          ] GC(14) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.528ms
[64.397s][info ][gc          ] GC(15) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.513ms
[68.839s][info ][gc          ] GC(16) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.191ms
[73.267s][info ][gc          ] GC(17) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.096ms
[77.696s][info ][gc          ] GC(18) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.598ms
[82.131s][info ][gc          ] GC(19) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.438ms
[86.560s][info ][gc          ] GC(20) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.162ms
[90.988s][info ][gc          ] GC(21) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.145ms
[95.412s][info ][gc          ] GC(22) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.095ms
[99.848s][info ][gc          ] GC(23) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.407ms
[104.272s][info ][gc          ] GC(24) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.226ms
[108.704s][info ][gc          ] GC(25) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.741ms
[113.126s][info ][gc          ] GC(26) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.851ms
[117.552s][info ][gc          ] GC(27) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.349ms
[120.080s][info ][gc             ] GC(28) Pause Full (System.gc()) 232M->1M(2048M) 33.952ms
[124.485s][info ][gc             ] GC(29) Pause Young (Normal) (G1 Evacuation Pause) 410M->1M(2048M) 2.428ms
[128.891s][info ][gc             ] GC(30) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.091ms
[133.289s][info ][gc             ] GC(31) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.341ms
[137.707s][info ][gc             ] GC(32) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.197ms
[142.122s][info ][gc             ] GC(33) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.030ms
[146.525s][info ][gc             ] GC(34) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.142ms
[150.931s][info ][gc             ] GC(35) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.271ms
[155.336s][info ][gc             ] GC(36) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.309ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754): Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/249.diff">https://git.openjdk.org/jdk22u/pull/249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/249#issuecomment-2176501173)