### PR TITLE
8332880: JFR GCHelper class recognizes "Archive" regions as valid

### DIFF
--- a/test/lib/jdk/test/lib/jfr/GCHelper.java
+++ b/test/lib/jdk/test/lib/jfr/GCHelper.java
@@ -195,8 +195,7 @@ public class GCHelper {
                                                            "Survivor",
                                                            "Starts Humongous",
                                                            "Continues Humongous",
-                                                           "Old",
-                                                           "Archive"
+                                                           "Old"
                                                          };
 
         g1HeapRegionTypes = Collections.unmodifiableList(Arrays.asList(g1HeapRegionTypeLiterals));


### PR DESCRIPTION
Hi all,

This pull request contains a backport [JDK-8332880](https://bugs.openjdk.org/browse/JDK-8332880) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by
Thomas Schatzl  on 29 May 2024 and was reviewed by Albert Mingkun Yang and Ivan Walulya.

The patch applies cleanly.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8332880](https://bugs.openjdk.org/browse/JDK-8332880) needs maintainer approval

### Issue
 * [JDK-8332880](https://bugs.openjdk.org/browse/JDK-8332880): JFR GCHelper class recognizes "Archive" regions as valid (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22u.git pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.org/jdk22u.git pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22u/pull/252.diff">https://git.openjdk.org/jdk22u/pull/252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22u/pull/252#issuecomment-2200113386)